### PR TITLE
Add support for tag types to withAllTags and withAnyTags

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -52,13 +52,13 @@ trait HasTags
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeWithAllTags(Builder $query, $tags): Builder
+    public function scopeWithAllTags(Builder $query, $tags, string $type = null): Builder
     {
-        $tags = static::convertToTags($tags);
+        $tags = static::convertToTags($tags, $type);
 
-        collect($tags)->each(function ($tag) use ($query) {
-            $query->whereHas('tags', function (Builder $query) use ($tag) {
-                return $query->where('id', $tag ? $tag->id : 0);
+        collect($tags)->each(function ($tag) use ($query, $type) {
+            $query->whereHas('tags', function (Builder $query) use ($tag, $type) {
+                return $query->where('id', $tag ? $tag->id : 0)->where('tags.type', $type);
             });
         });
 
@@ -71,14 +71,14 @@ trait HasTags
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeWithAnyTags(Builder $query, $tags): Builder
+    public function scopeWithAnyTags(Builder $query, $tags, string $type = null): Builder
     {
-        $tags = static::convertToTags($tags);
+        $tags = static::convertToTags($tags, $type);
 
-        return $query->whereHas('tags', function (Builder $query) use ($tags) {
+        return $query->whereHas('tags', function (Builder $query) use ($tags, $type) {
             $tagIds = collect($tags)->pluck('id');
 
-            $query->whereIn('id', $tagIds);
+            $query->whereIn('id', $tagIds)->where('tags.type', $type);
         });
     }
 
@@ -161,7 +161,6 @@ trait HasTags
         }
 
         $this->tags()->sync($tags->pluck('id')->toArray());
-
 
         return $this;
     }

--- a/tests/HasTagsScopesTest.php
+++ b/tests/HasTagsScopesTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Translatable\Test;
 
+use Spatie\Tags\Tag;
 use Spatie\Tags\Test\TestCase;
 use Spatie\Tags\Test\TestModel;
 
@@ -33,6 +34,14 @@ class HasTagsScopesTest extends TestCase
             'name' => 'model4',
             'tags' => ['tagD'],
         ]);
+
+        $typedTag = Tag::findOrCreate('tagE', 'typedTag');
+        $anotherTypedTag = Tag::findOrCreate('tagF', 'typedTag');
+
+        TestModel::create([
+            'name' => 'model5',
+            'tags' => [$typedTag, $anotherTypedTag],
+        ]);
     }
 
     /** @test */
@@ -61,5 +70,25 @@ class HasTagsScopesTest extends TestCase
         $testModels = TestModel::withAllTags(['tagB', 'tagC'])->get();
 
         $this->assertEquals(['model3'], $testModels->pluck('name')->toArray());
+    }
+
+    /** @test */
+    public function it_provides_as_scope_to_get_all_models_that_have_any_of_the_given_tags_with_type()
+    {
+        $testModels = TestModel::withAnyTags(['tagE'], 'typedTag')->get();
+
+        $this->assertEquals(['model5'], $testModels->pluck('name')->toArray());
+
+        $testModels = TestModel::withAnyTags(['tagF'], 'typedTag')->get();
+
+        $this->assertEquals(['model5'], $testModels->pluck('name')->toArray());
+    }
+
+    /** @test */
+    public function it_provides_as_scope_to_get_all_models_that_have_all_of_the_given_tags_with_type()
+    {
+        $testModels = TestModel::withAllTags(['tagE', 'tagF'], 'typedTag')->get();
+
+        $this->assertEquals(['model5'], $testModels->pluck('name')->toArray());
     }
 }


### PR DESCRIPTION
I added an option to add the tag type parameter to withAllTags and withAnyTags methods. Otherwise you cannot use them at all with typed tags.