### PR TITLE
Made the $type argument optional in some scopes/methods

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -58,7 +58,11 @@ trait HasTags
 
         collect($tags)->each(function ($tag) use ($query, $type) {
             $query->whereHas('tags', function (Builder $query) use ($tag, $type) {
-                return $query->where('id', $tag ? $tag->id : 0)->where('tags.type', $type);
+                $query->where('id', $tag ? $tag->id : 0);
+
+                if(! empty($type)) {
+                    $query->where('tags.type', $type);
+                }
             });
         });
 
@@ -78,7 +82,11 @@ trait HasTags
         return $query->whereHas('tags', function (Builder $query) use ($tags, $type) {
             $tagIds = collect($tags)->pluck('id');
 
-            $query->whereIn('id', $tagIds)->where('tags.type', $type);
+            $query->whereIn('id', $tagIds);
+
+            if(! empty($type)) {
+                $query->where('tags.type', $type);
+            }
         });
     }
 

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -60,7 +60,7 @@ trait HasTags
             $query->whereHas('tags', function (Builder $query) use ($tag, $type) {
                 $query->where('id', $tag ? $tag->id : 0);
 
-                if(! empty($type)) {
+                if (! empty($type)) {
                     $query->where('tags.type', $type);
                 }
             });
@@ -84,7 +84,7 @@ trait HasTags
 
             $query->whereIn('id', $tagIds);
 
-            if(! empty($type)) {
+            if (! empty($type)) {
                 $query->where('tags.type', $type);
             }
         });

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -55,10 +55,14 @@ class Tag extends Model implements Sortable
     {
         $locale = $locale ?? app()->getLocale();
 
-        return static::query()
-            ->where("name->{$locale}", $name)
-            ->where('type', $type)
-            ->first();
+        $query = static::query()
+            ->where("name->{$locale}", $name);
+
+        if(! empty($type)) {
+            $query->where('type', $type);
+        }
+
+        return $query->first();
     }
 
     protected static function findOrCreateFromString(string $name, string $type = null, string $locale = null): Tag

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -58,7 +58,7 @@ class Tag extends Model implements Sortable
         $query = static::query()
             ->where("name->{$locale}", $name);
 
-        if(! empty($type)) {
+        if (! empty($type)) {
             $query->where('type', $type);
         }
 

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -168,15 +168,9 @@ class HasTagsTest extends TestCase
         $model1->tags()->attach(Tag::findOrCreate('test1', 'type1'));
         $model1->tags()->attach(Tag::findOrCreate('test2', 'type1'));
 
-        $model2 = TestModel::create([
-            'name' => 'model2'
-        ]);
-        $model2->tags()->attach(Tag::findOrCreate('test1', 'type2'));
-        $model2->tags()->attach(Tag::findOrCreate('test2', 'type2'));
-
         $testModels = TestModel::withAllTags(['test1', 'test2']);
 
-        $this->assertEquals(['model1', 'model2'], $testModels->pluck('name')->toArray());
+        $this->assertEquals(['model1'], $testModels->pluck('name')->toArray());
     }
 
     /** @test */

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -147,11 +147,11 @@ class HasTagsTest extends TestCase
     public function it_provides_a_scope_to_get_all_models_that_have_any_of_the_given_tags_without_specifying_type()
     {
         TestModel::create([
-            'name' => 'model1'
+            'name' => 'model1',
         ])->tags()->attach(Tag::findOrCreate('test1', 'type1'));
 
         TestModel::create([
-            'name' => 'model2'
+            'name' => 'model2',
         ])->tags()->attach(Tag::findOrCreate('test2', 'type2'));
 
         $testModels = TestModel::withAnyTags(['test1', 'test2']);
@@ -163,7 +163,7 @@ class HasTagsTest extends TestCase
     public function it_provides_a_scope_to_get_all_models_that_have_all_of_the_given_tags_without_specifying_type()
     {
         $model1 = TestModel::create([
-            'name' => 'model1'
+            'name' => 'model1',
         ]);
         $model1->tags()->attach(Tag::findOrCreate('test1', 'type1'));
         $model1->tags()->attach(Tag::findOrCreate('test2', 'type1'));

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -160,6 +160,26 @@ class HasTagsTest extends TestCase
     }
 
     /** @test */
+    public function it_provides_a_scope_to_get_all_models_that_have_all_of_the_given_tags_without_specifying_type()
+    {
+        $model1 = TestModel::create([
+            'name' => 'model1'
+        ]);
+        $model1->tags()->attach(Tag::findOrCreate('test1', 'type1'));
+        $model1->tags()->attach(Tag::findOrCreate('test2', 'type1'));
+
+        $model2 = TestModel::create([
+            'name' => 'model2'
+        ]);
+        $model2->tags()->attach(Tag::findOrCreate('test1', 'type2'));
+        $model2->tags()->attach(Tag::findOrCreate('test2', 'type2'));
+
+        $testModels = TestModel::withAllTags(['test1', 'test2']);
+
+        $this->assertEquals(['model1', 'model2'], $testModels->pluck('name')->toArray());
+    }
+
+    /** @test */
     public function it_can_sync_a_single_tag()
     {
         $this->testModel->attachTags(['tag1', 'tag2', 'tag3']);

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -144,6 +144,22 @@ class HasTagsTest extends TestCase
     }
 
     /** @test */
+    public function it_provides_a_scope_to_get_all_models_that_have_any_of_the_given_tags_without_specifying_type()
+    {
+        TestModel::create([
+            'name' => 'model1'
+        ])->tags()->attach(Tag::findOrCreate('test1', 'type1'));
+
+        TestModel::create([
+            'name' => 'model2'
+        ])->tags()->attach(Tag::findOrCreate('test2', 'type2'));
+
+        $testModels = TestModel::withAnyTags(['test1', 'test2']);
+
+        $this->assertEquals(['model1', 'model2'], $testModels->pluck('name')->toArray());
+    }
+
+    /** @test */
     public function it_can_sync_a_single_tag()
     {
         $this->testModel->attachTags(['tag1', 'tag2', 'tag3']);

--- a/tests/TagTest.php
+++ b/tests/TagTest.php
@@ -95,6 +95,14 @@ class TagTest extends TestCase
     }
 
     /** @test */
+    public function it_can_find_a_tag_without_specifying_a_specific_type()
+    {
+        Tag::findOrCreate('tagA', 'firstType');
+
+        $this->assertEquals(['tagA'], Tag::findFromString('tagA')->pluck('name')->toArray());
+    }
+
+    /** @test */
     public function it_will_not_create_a_tag_if_the_tag_already_exists()
     {
         Tag::findOrCreate('string');


### PR DESCRIPTION
By default the `$type` argument in `withAnyTags`, `withAllTags` and `Tag::findFromString` was set to `null` when it was left unset. This made the query look for `Tag`s without a type instead of all tags `Tag`s with the provided names.