### PR TITLE
Removed where clauses from HasTags::withAnyTags and HasTags::withAllTags

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -57,7 +57,7 @@ trait HasTags
         $tags = static::convertToTags($tags, $type);
 
         collect($tags)->each(function ($tag) use ($query, $type) {
-            $query->whereHas('tags', function (Builder $query) use ($tag, $type) {
+            $query->whereHas('tags', function (Builder $query) use ($tag) {
                 return $query->where('id', $tag ? $tag->id : 0);
             });
         });
@@ -75,7 +75,7 @@ trait HasTags
     {
         $tags = static::convertToTags($tags, $type);
 
-        return $query->whereHas('tags', function (Builder $query) use ($tags, $type) {
+        return $query->whereHas('tags', function (Builder $query) use ($tags) {
             $tagIds = collect($tags)->pluck('id');
 
             $query->whereIn('id', $tagIds);

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -58,7 +58,7 @@ trait HasTags
 
         collect($tags)->each(function ($tag) use ($query, $type) {
             $query->whereHas('tags', function (Builder $query) use ($tag, $type) {
-                return $query->where('id', $tag ? $tag->id : 0)->where('tags.type', $type);
+                return $query->where('id', $tag ? $tag->id : 0);
             });
         });
 
@@ -78,7 +78,7 @@ trait HasTags
         return $query->whereHas('tags', function (Builder $query) use ($tags, $type) {
             $tagIds = collect($tags)->pluck('id');
 
-            $query->whereIn('id', $tagIds)->where('tags.type', $type);
+            $query->whereIn('id', $tagIds);
         });
     }
 

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -169,6 +169,10 @@ trait HasTags
     {
         return collect($values)->map(function ($value) use ($type, $locale) {
             if ($value instanceof Tag) {
+                if (isset($type) && $value->type != $type) {
+                    new \InvalidArgumentException("Type was set to {$type} but tag is of type {$value->type}");
+                }
+
                 return $value;
             }
 

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -152,7 +152,7 @@ class HasTagsTest extends TestCase
             'name' => 'model1',
         ])->attachTag($tag);
 
-        $testModels = TestModel::withAnyTags([$tag], 'typeA');
+        $testModels = TestModel::withAnyTags([$tag]);
 
         $this->assertEquals(['model1'], $testModels->pluck('name')->toArray());
     }


### PR DESCRIPTION
The `convertToTags` method will already return tags with the filtered `$type`. 