### PR TITLE
enable support for not MySQL DB engines

### DIFF
--- a/src/Tag.php
+++ b/src/Tag.php
@@ -61,6 +61,7 @@ class Tag extends Model implements Sortable
                 ->where('type', $type)
                 ->first();
         }
+
         return static::query()
             ->where('name', 'LIKE', '%'.$name.'%')
             ->where('type', $type)

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -55,17 +55,17 @@ class Tag extends Model implements Sortable
     {
         $locale = $locale ?? app()->getLocale();
 
-        if(app('db')->getDriverName() == 'mysql') {
+        if (app('db')->getDriverName() == 'mysql') {
             return static::query()
                 ->where("name->{$locale}", $name)
                 ->where('type', $type)
                 ->first();
         } else {
             return static::query()
-                ->where("name", 'LIKE', '%'.$name.'%')
+                ->where('name', 'LIKE', '%'.$name.'%')
                 ->where('type', $type)
                 ->get()
-                ->filter(function(Tag $tag) use ($name, $locale) {
+                ->filter(function (Tag $tag) use ($name, $locale) {
                     return $tag->getTranslation('name', $locale) == $name;
                 })
                 ->first();

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -60,16 +60,15 @@ class Tag extends Model implements Sortable
                 ->where("name->{$locale}", $name)
                 ->where('type', $type)
                 ->first();
-        } else {
-            return static::query()
-                ->where('name', 'LIKE', '%'.$name.'%')
-                ->where('type', $type)
-                ->get()
-                ->filter(function (Tag $tag) use ($name, $locale) {
-                    return $tag->getTranslation('name', $locale) == $name;
-                })
-                ->first();
         }
+        return static::query()
+            ->where('name', 'LIKE', '%'.$name.'%')
+            ->where('type', $type)
+            ->get()
+            ->filter(function (Tag $tag) use ($name, $locale) {
+                return $tag->getTranslation('name', $locale) == $name;
+            })
+            ->first();
     }
 
     protected static function findOrCreateFromString(string $name, string $type = null, string $locale = null): Tag

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -55,10 +55,21 @@ class Tag extends Model implements Sortable
     {
         $locale = $locale ?? app()->getLocale();
 
-        return static::query()
-            ->where("name->{$locale}", $name)
-            ->where('type', $type)
-            ->first();
+        if(app('db')->getDriverName() == 'mysql') {
+            return static::query()
+                ->where("name->{$locale}", $name)
+                ->where('type', $type)
+                ->first();
+        } else {
+            return static::query()
+                ->where("name", 'LIKE', '%'.$name.'%')
+                ->where('type', $type)
+                ->get()
+                ->filter(function(Tag $tag) use ($name, $locale) {
+                    return $tag->getTranslation('name', $locale) == $name;
+                })
+                ->first();
+        }
     }
 
     protected static function findOrCreateFromString(string $name, string $type = null, string $locale = null): Tag

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -63,7 +63,7 @@ class Tag extends Model implements Sortable
         }
 
         return static::query()
-            ->where('name', 'LIKE', '%'.$name.'%')
+            ->where('name', 'LIKE', '%"'.$name.'"%')
             ->where('type', $type)
             ->get()
             ->filter(function (Tag $tag) use ($name, $locale) {


### PR DESCRIPTION
the JSON where syntax works just in MySQL - with this fix it's possible to use this package also with other engines like SQLite. If you won't merge this pls let me know - atm I fixed it by overriding the default model and trait.