### PR TITLE
Add proper type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ $tag->save();
 
 //using tag types
 $tag = Tag::create('tag 1', 'my type');
+$newsItem->syncTags($tag);
+$newsItem->syncTags(['tag 2', 'tag 3'], 'another type');
+
+//retrieve tags for a particular type
+$newsItem->tagsWithType('my type');
+
 
 //tags have slugs
 $tag = Tag::create('yet another tag');

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ $newsItem->syncTags(['tag 2', 'tag 3'], 'another type');
 //retrieve tags for a particular type
 $newsItem->tagsWithType('my type');
 
-
 //tags have slugs
 $tag = Tag::create('yet another tag');
 $tag->slug; //returns "yet-another-tag"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ $newsItem->detachTags(['tag4', 'tag5']);
 //syncing tags
 $newsItem->syncTags(['tag1', 'tag2']); // all other tags on this model will be detached
 
+//syncing tags with a type
+$newsItem->syncTagsWithType(['tag1', 'tag2'], 'typeA'); 
+$newsItem->syncTagsWithType(['tag1', 'tag2'], 'typeB'); 
+
+//retrieving tags with a type
+$newsItem->tagsWithType('typeA'); 
+$newsItem->tagsWithType('typeB'); 
+
 //retrieving models that have any of the given tags
 NewsItem::withAnyTags(['tag1', 'tag2']);
 
@@ -47,11 +55,6 @@ $tag->save();
 
 //using tag types
 $tag = Tag::create('tag 1', 'my type');
-$newsItem->syncTags($tag);
-$newsItem->syncTags(['tag 2', 'tag 3'], 'another type');
-
-//retrieve tags for a particular type
-$newsItem->tagsWithType('my type');
 
 //tags have slugs
 $tag = Tag::create('yet another tag');

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -82,6 +82,10 @@ trait HasTags
         });
     }
 
+    /**
+     * @param string|null $type
+     * @return Collection
+     */
     public function tagsWithType(string $type = null): Collection
     {
         return $this->tags->filter(function (Tag $tag) use ($type) {
@@ -91,28 +95,30 @@ trait HasTags
 
     /**
      * @param array|\ArrayAccess|\Spatie\Tags\Tag $tags
+     * @param string|null $type
      *
      * @return $this
      */
-    public function attachTags($tags)
+    public function attachTags($tags, string $type = null)
     {
         $className = static::getTagClassName();
 
-        $tags = collect($className::findOrCreate($tags));
+        $tags = collect($className::findOrCreate($tags, $type));
 
-        $this->tags()->syncWithoutDetaching($tags->pluck('id')->toArray());
+        $this->tags()->syncTagIds($tags->pluck('id')->toArray(), $type, false);
 
         return $this;
     }
 
     /**
      * @param string|\Spatie\Tags\Tag $tag
+     * @param string|null $type
      *
      * @return $this
      */
-    public function attachTag($tag)
+    public function attachTag($tag, string $type = null)
     {
-        return $this->attachTags([$tag]);
+        return $this->attachTags([$tag], $type);
     }
 
     /**
@@ -145,21 +151,28 @@ trait HasTags
 
     /**
      * @param array|\ArrayAccess $tags
+     * @param string|null $type
      *
      * @return $this
      */
-    public function syncTags($tags)
+    public function syncTags($tags, string $type = null)
     {
         $className = static::getTagClassName();
 
-        $tags = collect($className::findOrCreate($tags));
-
-        $this->tags()->sync($tags->pluck('id')->toArray());
+        $tags = collect($className::findOrCreate($tags, $type));
+        $this->syncTagIds($tags->pluck('id')->toArray(), $type);
 
         return $this;
     }
 
-    protected static function convertToTags($values, $type = null, $locale = null)
+    /**
+     * @param mixed $values
+     * @param string|null $type
+     * @param string|null $locale
+     *
+     * @return static
+     */
+    protected static function convertToTags($values, string $type = null, $locale = null)
     {
         return collect($values)->map(function ($value) use ($type, $locale) {
             if ($value instanceof Tag) {
@@ -174,5 +187,56 @@ trait HasTags
 
             return $className::findFromString($value, $type, $locale);
         });
+    }
+
+    /**
+     * Use in place of eloquent's sync() method so that the tag type may be optionally specified.
+     * @param $ids
+     * @param string|null $type
+     * @param bool $detaching
+     */
+    protected function syncTagIds($ids, string $type = null, $detaching = true)
+    {
+        $isUpdated = false;
+
+        // Get a list of tag_ids for all current tags
+        $current = $this->tags()
+            ->newPivotStatement()
+            ->where('taggable_id', $this->getKey())
+            ->when(!empty($type), function($query) use ($type) {
+                $tagModel = $this->tags()->getRelated();
+                $query->join(
+                        $tagModel->getTable(),
+                        'taggables.tag_id',
+                        '=',
+                        $tagModel->getTable().'.'.$tagModel->getKeyName()
+                    )
+                    ->where('tags.type', $type);
+            })
+            ->pluck('tag_id')
+            ->all();
+
+        // Compare to the list of ids given to find the tags to remove
+        $detach = array_diff($current, $ids);
+        if ($detaching && count($detach) > 0) {
+            $this->tags()->detach($detach);
+            $isUpdated = true;
+        }
+
+        // Attach any new ids
+        $attach = array_diff($ids, $current);
+        if (count($attach) > 0) {
+            collect($attach)->each(function($id) {
+                $this->tags()->attach($id, []);
+            });
+            $isUpdated = true;
+        }
+
+        // Once we have finished attaching or detaching the records, we will see if we
+        // have done any attaching or detaching, and if we have we will touch these
+        // relationships if they are configured to touch on any database updates.
+        if ($isUpdated) {
+            $this->tags()->touchIfTouching();
+        }
     }
 }

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -56,7 +56,7 @@ trait HasTags
     {
         $tags = static::convertToTags($tags, $type);
 
-        collect($tags)->each(function ($tag) use ($query, $type) {
+        collect($tags)->each(function ($tag) use ($query) {
             $query->whereHas('tags', function (Builder $query) use ($tag) {
                 return $query->where('id', $tag ? $tag->id : 0);
             });
@@ -203,7 +203,7 @@ trait HasTags
         $current = $this->tags()
             ->newPivotStatement()
             ->where('taggable_id', $this->getKey())
-            ->when(!empty($type), function($query) use ($type) {
+            ->when(! empty($type), function ($query) use ($type) {
                 $tagModel = $this->tags()->getRelated();
                 $query->join(
                         $tagModel->getTable(),
@@ -226,7 +226,7 @@ trait HasTags
         // Attach any new ids
         $attach = array_diff($ids, $current);
         if (count($attach) > 0) {
-            collect($attach)->each(function($id) {
+            collect($attach)->each(function ($id) {
                 $this->tags()->attach($id, []);
             });
             $isUpdated = true;

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -198,5 +198,4 @@ class HasTagsTest extends TestCase
         $tagsOfTypeB = $this->testModel->tagsWithType('typeB');
         $this->assertEquals(['tagB1', 'tagB2'], $tagsOfTypeB->pluck('name')->toArray());
     }
-
 }

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -185,4 +185,18 @@ class HasTagsTest extends TestCase
 
         $this->assertEquals(['tag3', 'tag4'], $this->testModel->tags->pluck('name')->toArray());
     }
+
+    /** @test */
+    public function it_can_sync_tags_with_different_types()
+    {
+        $this->testModel->syncTagsWithType(['tagA1', 'tagA2', 'tagA3'], 'typeA');
+        $this->testModel->syncTagsWithType(['tagB1', 'tagB2'], 'typeB');
+
+        $tagsOfTypeA = $this->testModel->tagsWithType('typeA');
+        $this->assertEquals(['tagA1', 'tagA2', 'tagA3'], $tagsOfTypeA->pluck('name')->toArray());
+
+        $tagsOfTypeB = $this->testModel->tagsWithType('typeB');
+        $this->assertEquals(['tagB1', 'tagB2'], $tagsOfTypeB->pluck('name')->toArray());
+    }
+
 }


### PR DESCRIPTION
Regarding Issue #43 -

There was currently an issue when using multiple types that as soon as you used the `syncTags()` method to update the tags it would wipe out any other type.

I've implemented a new `syncTagIds()` method instead of using `sync()` directly off the relationship as the eloquent sync does not support having a where condition (needed to ensure we only sync a particular type).

Further to this, in order to make it easier to use types, I've added the optional `$type` argument to both `attachTags()`, `attachTag()` and `syncTags()` methods.