### PR TITLE
prevent detaching tags when model is soft deleted

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -26,6 +26,10 @@ trait HasTags
         });
 
         static::deleted(function (Model $deletedModel) {
+            if (method_exists($deletedModel, 'isForceDeleting') && ! $deletedModel->isForceDeleting()) {
+                return;
+            }
+            
             $tags = $deletedModel->tags()->get();
 
             $deletedModel->detachTags($tags);


### PR DESCRIPTION
Related to https://github.com/spatie/laravel-tags/pull/99#issuecomment-374743220, https://github.com/spatie/laravel-tags/issues/98 and https://github.com/spatie/laravel-tags/issues/83