### PR TITLE
Syntax error with MariaDB on SELECT statement

### DIFF
--- a/src/Tag.php
+++ b/src/Tag.php
@@ -63,7 +63,7 @@ class Tag extends Model implements Sortable
         $locale = $locale ?? app()->getLocale();
 
         return static::query()
-            ->where(DB::raw('JSON_EXTRACT(`name`, "$.{$locale}")'), '=', $name)
+            ->whereRaw('JSON_EXTRACT(`name`, "$.' . $locale . '") = ?', [$name])
             ->where('type', $type)
             ->first();
     }


### PR DESCRIPTION
Hey everyone,

I saw this problem discussed in issue #123 but I still wanted to create this pull request.
It might be a problem with Laravel, but until they can get to fixing it this change should allow people using MariaDB to use this amazing package.
Please let me know if I there is anything else I can do to get this merged, until then we will be using this fork.

If anyone is in need of this change you can configure composer to use the fork like so:
```
"repositories": [
    {
        "type": "git",
        "url": "https://github.com/LynxSolutions/laravel-tags"
    }
],
"require": {
    "spatie/laravel-tags": "dev-master as 2.1"
},
```