### PR TITLE
withAllTags performance enhancement 

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -64,8 +64,10 @@ trait HasTags
         $tags = static::convertToTags($tags, $type);
 
         collect($tags)->each(function ($tag) use ($query) {
-            $query->whereHas('tags', function (Builder $query) use ($tag) {
-                return $query->where('id', $tag ? $tag->id : 0);
+            $query->whereIn("{$this->table}.{$this->getKeyName()}", function($query) use ($tag) {
+                $query->from('taggables')
+                    ->select('taggables.taggable_id')
+                    ->where('taggables.tag_id', $tag ? $tag->id : 0);
             });
         });
 


### PR DESCRIPTION
Problem with whereHas its making new subquery for every tag . if you have many models & tags that would make your app very slow 

This pull request use whereIn instead  and it's about %90 faster 

![image](https://user-images.githubusercontent.com/199647/45595574-cda30700-b9b6-11e8-89f8-a79af887db24.png)
** The first two timing are ( whereHas ) rest are ( whereIn) 
