### PR TITLE
Added support for spatie/laravel-translatable 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.0",
         "laravel/framework": "~5.5.0|~5.6.0|~5.7.0",
         "spatie/eloquent-sortable": "^3.0",
-        "spatie/laravel-translatable": "^2.0"
+        "spatie/laravel-translatable": "^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2|^7.0",


### PR DESCRIPTION
As you can guess, I was using laravel-translatable 3.0 on a project and then, wanted to add laravel-tags. This pull request allows me (and probably others) to do that. Everything seems to still work as expected and won't break people's projects staying on laravel-translatable 2.0.