### PR TITLE
scopeWithAllTags relies on '$table' property

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -64,7 +64,7 @@ trait HasTags
         $tags = static::convertToTags($tags, $type);
 
         collect($tags)->each(function ($tag) use ($query) {
-            $query->whereIn("{$this->table}.{$this->getKeyName()}", function ($query) use ($tag) {
+            $query->whereIn("{$this->getTable()}.{$this->getKeyName()}", function ($query) use ($tag) {
                 $query->from('taggables')
                     ->select('taggables.taggable_id')
                     ->where('taggables.tag_id', $tag ? $tag->id : 0);


### PR DESCRIPTION
If the tagged model uses Laravel conventions and does not define the '$table' property, the scopeWithAllTags will fail.