### PR TITLE
Create test for syncing same tags on another model type

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -217,6 +217,7 @@ trait HasTags
         $current = $this->tags()
             ->newPivotStatement()
             ->where('taggable_id', $this->getKey())
+            ->where('taggable_type', self::class)
             ->when($type !== null, function ($query) use ($type) {
                 $tagModel = $this->tags()->getRelated();
 

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -201,13 +201,17 @@ class HasTagsTest extends TestCase
     }
 
     /** @test */
-    public function it_can_sync_same_tag_type_with_different_models()
+    public function it_can_sync_same_tag_type_with_different_models_with_same_foreign_id()
     {
         $this->testModel->syncTagsWithType(['tagA1', 'tagA2', 'tagA3'], 'typeA');
 
         $testAnotherModel = TestAnotherModel::create([
             'name' => 'model2',
         ])->syncTagsWithType(['tagA1'], 'typeA');
+
+        // They should have the same foreign ID in taggables table
+        $this->assertEquals('1', $this->testModel->id);
+        $this->assertEquals('1', $testAnotherModel->id);
 
         $testAnotherModelTagsOfTypeA = $testAnotherModel->tagsWithType('typeA');
         $this->assertEquals(['tagA1'], $testAnotherModelTagsOfTypeA->pluck('name')->toArray());

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -5,6 +5,7 @@ namespace Spatie\Translatable\Test;
 use Spatie\Tags\Tag;
 use Spatie\Tags\Test\TestCase;
 use Spatie\Tags\Test\TestModel;
+use Spatie\Tags\Test\TestAnotherModel;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 class HasTagsTest extends TestCase
@@ -197,6 +198,19 @@ class HasTagsTest extends TestCase
 
         $tagsOfTypeB = $this->testModel->tagsWithType('typeB');
         $this->assertEquals(['tagB1', 'tagB2'], $tagsOfTypeB->pluck('name')->toArray());
+    }
+
+    /** @test */
+    public function it_can_sync_same_tag_type_with_different_models()
+    {
+        $this->testModel->syncTagsWithType(['tagA1', 'tagA2', 'tagA3'], 'typeA');
+
+        $testAnotherModel = TestAnotherModel::create([
+            'name' => 'model2',
+        ])->syncTagsWithType(['tagA1'], 'typeA');
+
+        $testAnotherModelTagsOfTypeA = $testAnotherModel->tagsWithType('typeA');
+        $this->assertEquals(['tagA1'], $testAnotherModelTagsOfTypeA->pluck('name')->toArray());
     }
 
     /** @test */

--- a/tests/TestAnotherModel.php
+++ b/tests/TestAnotherModel.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\Tags\Test;
+
+use Spatie\Tags\HasTags;
+use Illuminate\Database\Eloquent\Model;
+
+class TestAnotherModel extends Model
+{
+    use HasTags;
+
+    public $table = 'test_another_models';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -66,6 +66,11 @@ abstract class TestCase extends Orchestra
             $table->increments('id');
             $table->string('name')->nullable();
         });
+
+        $app['db']->connection()->getSchemaBuilder()->create('test_another_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+        });
     }
 
     protected function dropAllTables()


### PR DESCRIPTION
I discovered a bug why working with same tags/type while connected to multiple model classes. I found out an issue was already filed which describes what I found, https://github.com/spatie/laravel-tags/issues/104. 

So I went ahead an tried to write a test that could demonstrate the issue. 

```bash
1) Spatie\Translatable\Test\HasTagsTest::it_can_sync_same_tag_type_with_different_models
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'tagA1'
 )
```

I was not quite sure how to fix the issue however, as I am not greatly familiar with polymorphic relations. The tag is not assigned to the second model instance (of another Model class). It seems to me the `syncTagIds` method in `HasTags` trait does not query filter using the `taggable_type` field (model calss name) but just gets all `taggable` rows with the tag "tagA1".

Probably some thing on this line has to change, https://github.com/spatie/laravel-tags/blob/master/src/HasTags.php#L218