### PR TITLE
Tag tips for pt-BR not working

### DIFF
--- a/src/Tag.php
+++ b/src/Tag.php
@@ -30,7 +30,9 @@ class Tag extends Model implements Sortable
     {
         $locale = $locale ?? app()->getLocale();
 
-        return $query->whereRaw('LOWER(JSON_EXTRACT(name, "$.'.$locale.'")) like ?', ['"%'.strtolower($name).'%"']);
+        $locale = '"'.$locale.'"';
+
+        return $query->whereRaw("LOWER(JSON_EXTRACT(name, '$.".$locale."')) like ?", ['"%'.strtolower($name).'%"']);
     }
 
     /**


### PR DESCRIPTION
According to MySQL manual, name of keys must be double-quoted strings in JSON_EXTRACT function.

https://dev.mysql.com/doc/refman/5.7/en/json-path-syntax.html

Query with key string like ```pt-BR```, with dash (hyphen), gives zero result if without double-quote.