### PR TITLE
Allows models with any/all tags to be found disregarding type by passing false

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ NewsItem::withAnyTags(['tag1', 'tag2'])->get();
 //retrieve models that have all of the given tags
 NewsItem::withAllTags(['tag1', 'tag2'])->get();
 
+//retrieve models that have all of the given tags, having any type
+NewsItem::withAllTags(['tag1', 'tag2'], false)->get();
+
 //translating a tag
 $tag = Tag::findOrCreate('my tag');
 $tag->setTranslation('fr', 'mon tag');

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -189,7 +189,7 @@ trait HasTags
     {
         return collect($values)->map(function ($value) use ($type, $locale) {
             if ($value instanceof Tag) {
-                if (isset($type) && $value->type != $type) {
+                if (! empty($type) && $value->type != $type) {
                     throw new InvalidArgumentException("Type was set to {$type} but tag is of type {$value->type}");
                 }
 

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -64,10 +64,15 @@ class Tag extends Model implements Sortable
     {
         $locale = $locale ?? app()->getLocale();
 
-        return static::query()
-            ->where("name->{$locale}", $name)
-            ->where('type', $type)
-            ->first();
+        $query = static::query()->where("name->{$locale}", $name);
+
+        if ($type === null) {
+            $query->whereNull('type');
+        } elseif ($type) {
+            $query->where('type', $type);
+        }
+
+        return $query->first();
     }
 
     protected static function findOrCreateFromString(string $name, string $type = null, string $locale = null): self
@@ -79,7 +84,7 @@ class Tag extends Model implements Sortable
         if (! $tag) {
             $tag = static::create([
                 'name' => [$locale => $name],
-                'type' => $type,
+                'type' => $type ? $type : null,
             ]);
         }
 

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -167,6 +167,34 @@ class HasTagsTest extends TestCase
     }
 
     /** @test */
+    public function it_provides_a_scope_to_get_all_models_that_have_any_of_the_provided_tags_ignoring_type()
+    {
+        $tag = Tag::findOrCreate('tagA', 'typeA');
+
+        TestModel::create([
+            'name' => 'model1',
+        ])->attachTag($tag);
+
+        $testModelsAny = TestModel::withAnyTags([$tag], false);
+
+        $this->assertEquals(['model1'], $testModelsAny->pluck('name')->toArray());
+    }
+
+    /** @test */
+    public function it_provides_a_scope_to_get_all_models_that_have_all_of_the_provided_tags_ignoring_type()
+    {
+        $tag = Tag::findOrCreate('tagA', 'typeA');
+
+        TestModel::create([
+            'name' => 'model1',
+        ])->attachTag($tag);
+
+        $testModelsAll = TestModel::withAllTags([$tag], false);
+
+        $this->assertEquals(['model1'], $testModelsAll->pluck('name')->toArray());
+    }
+
+    /** @test */
     public function it_can_sync_a_single_tag()
     {
         $this->testModel->attachTags(['tag1', 'tag2', 'tag3']);

--- a/tests/TagTest.php
+++ b/tests/TagTest.php
@@ -172,6 +172,15 @@ class TagTest extends TestCase
         $this->assertEquals('string', $tag2->name);
     }
 
+    public function it_can_find_tags_disregarding_type_when_passed_type_equal_to_false()
+    {
+        $tag = Tag::findOrCreate('tag with type', 'thisType');
+
+        $fetchedTag = Tag::findFromString('tag with type', false);
+
+        $this->assertEquals($tag->name, $fetchedTag->name);
+    }
+
     /** @test */
     public function its_name_can_be_changed_by_setting_its_name_property_to_a_new_value()
     {


### PR DESCRIPTION
We were finding it a little restrictive not to be able to retrieve models by tag(s), disregarding type. This allows type to be ignored by passing false into the trait methods withAnyTags() and withAllTags(). NULL behaves as current.

This does have some crossover with https://github.com/spatie/laravel-tags/pull/76, but is solving a different issue. This should only be breaking where false is being (inadvertently?) passed as second argument to methods above.

Tests added. All existing pass.