### PR TITLE
Allow seo-friendly urls (using slug instead of id)

### DIFF
--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -24,4 +24,16 @@ trait HasSlug
 
         return call_user_func($slugger, $this->getTranslation('name', $locale));
     }
+    
+    public function resolveRouteBinding($value)
+    {
+        $locale = app()->getLocale();
+
+        return $this->where("slug->{$locale}", $value)->first();
+    }
+
+    public function getRouteKeyName()
+    {
+        return 'slug';
+    }
 }


### PR DESCRIPTION
Is this how we want our tag urls looks like?
http://domain.com/tags/1
http://domain.com/tags/2
http://domain.com/tags/3
Probably not.

With this commit, all you need to do is to:
```php
// Define your tag route the way you usually do for other models
Route::get('tags/{tag}', [HomeController::class, 'tags'])->name('tags');
```

```php
// Define your tag route's method
class HomeController extends Controller
{
    public function tags(\Spatie\Tags\Tag $tag)
    {
        // gotcha!
        return $tag;
    }
}
```

And inside your blade files, wherever you need to output tag urls:
```blade
@foreach ($newsItem->tags as $tag)
    <a href="{{ route('tags', $tag) }}">
        {{ $tag->name }}
    </a>
@endforeach
```

Now your tags url will be like:
http://domain.com/tags/first-tag
http://domain.com/tags/second-tag
http://domain.com/tags/last-tag
The correct and seo-friendly way.