### PR TITLE
Update taggable_type filter

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -256,7 +256,7 @@ trait HasTags
         $current = $this->tags()
             ->newPivotStatement()
             ->where('taggable_id', $this->getKey())
-            ->where('taggable_type', self::class)
+            ->where('taggable_type', $this->getMorphClass())
             ->when($type !== null, function ($query) use ($type) {
                 $tagModel = $this->tags()->getRelated();
 


### PR DESCRIPTION
When the taggable class is included in the morph map, the self::class filter doesn't return any results which ends up duplicating tags on every model save. This fix uses the morph map name for taggable_type if it exists.