### PR TITLE
Convenience method to return tags with already translated and decoded name and slug fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,17 @@ NewsItem::withAllTags(['tag1', 'tag2'])->get();
 
 //translating a tag
 $tag = Tag::findOrCreate('my tag');
-$tag->setTranslation('fr', 'mon tag');
-$tag->setTranslation('nl', 'mijn tag');
+$tag->setTranslation('name', 'fr', 'mon tag');
+$tag->setTranslation('name', 'nl', 'mijn tag');
 $tag->save();
+
+//getting translations
+$tag->translate('name'); //returns my name
+$tag->translate('name', 'fr'); //returns mon tag (optional locale param)
+
+//convenient translations through taggable models
+$newsItem->tagsTranslated();// returns tags with slug_translated and name_translated properties
+$newsItem->tagsTranslated('fr');// returns tags with slug_translated and name_translated properties set for specified locale
 
 //using tag types
 $tag = Tag::findOrCreate('tag 1', 'my type');

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -44,13 +44,13 @@ trait HasTags
      */
     public function tagsTranslated($locale = null): MorphToMany
     {
-        $locale = !is_null($locale) ? $locale : app()->getLocale();
+        $locale = ! is_null($locale) ? $locale : app()->getLocale();
 
         return $this
             ->morphToMany(self::getTagClassName(), 'taggable')
             ->select('*')
             ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(name, '$.\"{$locale}\"')) as name_translated")
-            ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(slug, '$.\"{$locale}\"')) as slug_translated") 
+            ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(slug, '$.\"{$locale}\"')) as slug_translated")
             ->orderBy('order_column');
     }
 

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -44,13 +44,13 @@ trait HasTags
      */
     public function tagsTranslated($locale = null): MorphToMany
     {
-        if (is_null($locale)) {
-            $locale = app()->getLocale();
-        }
-        
+        $locale = !is_null($locale) ? $locale : app()->getLocale();
+
         return $this
             ->morphToMany(self::getTagClassName(), 'taggable')
-            ->select('id', 'name', "name->{$locale} as name_translated", 'slug', "slug->{$locale} as slug_translated", 'type', 'order_column', 'created_at', 'updated_at')
+            ->select('*')
+            ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(name, '$.\"{$locale}\"')) as name_translated")
+            ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(slug, '$.\"{$locale}\"')) as slug_translated") 
             ->orderBy('order_column');
     }
 

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -40,6 +40,20 @@ trait HasTags
     }
 
     /**
+     * @param string $locale
+     */
+    public function tagsTranslated($locale = null): MorphToMany
+    {
+        if (is_null($locale)) {
+            $locale = app()->getLocale();
+        }
+        return $this
+            ->morphToMany(self::getTagClassName(), 'taggable')
+            ->select('id', 'name', "name->{$locale} as name_translated", 'slug', "slug->{$locale} as slug_translated", 'type', 'order_column', 'created_at', 'updated_at')
+            ->orderBy('order_column');
+    }
+
+    /**
      * @param string|array|\ArrayAccess|\Spatie\Tags\Tag $tags
      */
     public function setTagsAttribute($tags)

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -47,6 +47,7 @@ trait HasTags
         if (is_null($locale)) {
             $locale = app()->getLocale();
         }
+        
         return $this
             ->morphToMany(self::getTagClassName(), 'taggable')
             ->select('id', 'name', "name->{$locale} as name_translated", 'slug', "slug->{$locale} as slug_translated", 'type', 'order_column', 'created_at', 'updated_at')

--- a/tests/HasTagsTranslatedTest.php
+++ b/tests/HasTagsTranslatedTest.php
@@ -5,8 +5,6 @@ namespace Spatie\Translatable\Test;
 use Spatie\Tags\Tag;
 use Spatie\Tags\Test\TestCase;
 use Spatie\Tags\Test\TestModel;
-use Spatie\Tags\Test\TestAnotherModel;
-use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 class HasTagsTranslatedTest extends TestCase
 {
@@ -25,12 +23,11 @@ class HasTagsTranslatedTest extends TestCase
     {
         $this->testModel->attachTag('My Tag');
 
-        $locale     = app()->getLocale();
+        $locale = app()->getLocale();
         $translated = $this->testModel->tagsTranslated->first()->toArray();
 
         $this->assertEquals($translated['name_translated'], $translated['name'][$locale]);        
         $this->assertEquals($translated['slug_translated'], $translated['slug'][$locale]);        
-
     }
 
     /** @test */
@@ -48,7 +45,6 @@ class HasTagsTranslatedTest extends TestCase
 
         $this->assertEquals($translated['name_translated'], $translated['name'][$locale]);        
         $this->assertEquals($translated['slug_translated'], $translated['slug'][$locale]);        
-
     }
 
 }

--- a/tests/HasTagsTranslatedTest.php
+++ b/tests/HasTagsTranslatedTest.php
@@ -11,7 +11,7 @@ class HasTagsTranslatedTest extends TestCase
     /** @var \Spatie\Tags\Test\TestModel */
     protected $testModel;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/HasTagsTranslatedTest.php
+++ b/tests/HasTagsTranslatedTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Spatie\Translatable\Test;
+
+use Spatie\Tags\Tag;
+use Spatie\Tags\Test\TestCase;
+use Spatie\Tags\Test\TestModel;
+use Spatie\Tags\Test\TestAnotherModel;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+
+class HasTagsTranslatedTest extends TestCase
+{
+    /** @var \Spatie\Tags\Test\TestModel */
+    protected $testModel;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->testModel = TestModel::create(['name' => 'default']);
+    }
+
+    /** @test */
+    public function it_provides_models_with_tag_name_and_slug_already_translated()
+    {
+        $this->testModel->attachTag('My Tag');
+
+        $locale     = app()->getLocale();
+        $translated = $this->testModel->tagsTranslated->first()->toArray();
+
+        $this->assertEquals($translated['name_translated'], $translated['name'][$locale]);        
+        $this->assertEquals($translated['slug_translated'], $translated['slug'][$locale]);        
+
+    }
+
+    /** @test */
+    public function it_can_provide_models_with_tag_name_and_slug_translated_for_alternate_locales()
+    {
+        $this->testModel->attachTag('My Tag');
+
+        $locale = 'fr';
+
+        $tag = $this->testModel->tags->first();
+        $tag->setTranslation('name', $locale, 'Mon tag');
+        $tag->save();
+
+        $translated = $this->testModel->tagsTranslated($locale)->first()->toArray();
+
+        $this->assertEquals($translated['name_translated'], $translated['name'][$locale]);        
+        $this->assertEquals($translated['slug_translated'], $translated['slug'][$locale]);        
+
+    }
+
+}

--- a/tests/HasTagsTranslatedTest.php
+++ b/tests/HasTagsTranslatedTest.php
@@ -26,8 +26,8 @@ class HasTagsTranslatedTest extends TestCase
         $locale = app()->getLocale();
         $translated = $this->testModel->tagsTranslated->first()->toArray();
 
-        $this->assertEquals($translated['name_translated'], $translated['name'][$locale]);        
-        $this->assertEquals($translated['slug_translated'], $translated['slug'][$locale]);        
+        $this->assertEquals($translated['name_translated'], $translated['name'][$locale]);
+        $this->assertEquals($translated['slug_translated'], $translated['slug'][$locale]);
     }
 
     /** @test */
@@ -43,8 +43,7 @@ class HasTagsTranslatedTest extends TestCase
 
         $translated = $this->testModel->tagsTranslated($locale)->first()->toArray();
 
-        $this->assertEquals($translated['name_translated'], $translated['name'][$locale]);        
-        $this->assertEquals($translated['slug_translated'], $translated['slug'][$locale]);        
+        $this->assertEquals($translated['name_translated'], $translated['name'][$locale]);
+        $this->assertEquals($translated['slug_translated'], $translated['slug'][$locale]);
     }
-
 }


### PR DESCRIPTION
Hey guys, 

Was running into what seemed like unnecessary difficulty (extra lines of code) to translate tag names and slugs in an API I'm developing for an SPA. This add simply allows the translation to be done at query time as opposed after the fact through collection manipulation (or something else) when one is trying to pass translated tag data to a view.

It becomes as simple as this:
`Post::with(['tagsTranslated'])->get();// by default uses app()->getLocale()`

Or this: 
`$post->tagsTranslated('en-US')->get(); // $locale param optional`

Example tag result: 
```
{
    id: 1
    name: {en-US: "Branding"}
    slug: {en-US: "branding"}
    name_translated: "Branding"
    slug_translated: "branding"
    ...
}
```

Compatible with MySQL >= 5.7 👍 

Happy to make changes as/if necessary. No worries of course if you'd rather leave it out, just thought I'd share. 

Cheers.