### PR TITLE
Added withType method to query models with typed tags

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -114,7 +114,7 @@ trait HasTags
      */
     public function scopeWithType(Builder $query, array $type) : Builder
     {
-        return $query->whereHas('tags', function (Builder $query) use ($type){
+        return $query->whereHas('tags', function (Builder $query) use ($type) {
             $query->whereIn('tags.type', $type);
         });
     }

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -106,6 +106,19 @@ trait HasTags
         });
     }
 
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param array $type
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeWithType(Builder $query, array $type) : Builder
+    {
+        return $query->whereHas('tags', function (Builder $query) use ($type){
+            $query->whereIn('tags.type', $type);
+        });
+    }
+
     public function scopeWithAllTagsOfAnyType(Builder $query, $tags): Builder
     {
         $tags = static::convertToTagsOfAnyType($tags);

--- a/tests/HasTagsScopesTest.php
+++ b/tests/HasTagsScopesTest.php
@@ -116,4 +116,12 @@ class HasTagsScopesTest extends TestCase
 
         $this->assertEquals(['model5'], $testModels->pluck('name')->toArray());
     }
+
+    /** @test */
+    public function it_provides_as_scope_to_get_all_models_that_have_the_given_type()
+    {
+        $testModels = TestModel::withType(['typedTag'])->get();
+
+        $this->assertEquals(['model5'], $testModels->pluck('name')->toArray());
+    }
 }

--- a/tests/HasTagsScopesTest.php
+++ b/tests/HasTagsScopesTest.php
@@ -122,6 +122,6 @@ class HasTagsScopesTest extends TestCase
     {
         $testModels = TestModel::withType(['typedTag'])->get();
 
-        $this->assertEquals(['model5'], $testModels->pluck('name')->toArray());
+        $this->assertEquals(['model5', 'model6'], $testModels->pluck('name')->toArray());
     }
 }


### PR DESCRIPTION
**Description**
Added a query builder to get models that have tags with given types.

**Params**
$type : Array of strings

**Usage**
```php
Model::withType(['firstType','secondType'])->get();
```
