### PR TITLE
Add method to retrieve all tags with translated name and slug fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,13 @@ $tag->save();
 $tag->translate('name'); //returns my name
 $tag->translate('name', 'fr'); //returns mon tag (optional locale param)
 
+//get all tags with translations
+$tags = Tag::getTranslated(); // returns all tags with slug_translated and name_translated properties
+$tags = Tag::getTranslated('fr'); // returns all tags with slug_translated and name_translated properties set for specified locale
+
 //convenient translations through taggable models
-$newsItem->tagsTranslated();// returns tags with slug_translated and name_translated properties
-$newsItem->tagsTranslated('fr');// returns tags with slug_translated and name_translated properties set for specified locale
+$newsItem->tagsTranslated();// returns a model's tags with slug_translated and name_translated properties
+$newsItem->tagsTranslated('fr');// returns a model's tags with slug_translated and name_translated properties set for specified locale
 
 //using tag types
 $tag = Tag::findOrCreate('tag 1', 'my type');

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -60,6 +60,16 @@ class Tag extends Model implements Sortable
         return static::withType($type)->ordered()->get();
     }
 
+    public static function getTranslated(string $locale = null)
+    {
+        $locale = $locale ?? app()->getLocale();
+
+        return self::select('*')
+            ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(name, '$.\"{$locale}\"')) as name_translated")
+            ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(slug, '$.\"{$locale}\"')) as slug_translated")
+            ->ordered();
+    }
+
     public static function findFromString(string $name, string $type = null, string $locale = null)
     {
         $locale = $locale ?? app()->getLocale();

--- a/tests/TagTest.php
+++ b/tests/TagTest.php
@@ -183,4 +183,31 @@ class TagTest extends TestCase
 
         $this->assertEquals('new name', $tag->name);
     }
+
+    /** @test */
+    public function it_provides_tags_with_name_and_slug_already_translated()
+    {
+        Tag::findOrCreate('Tag name');
+
+        $translated = Tag::getTranslated()->first()->toArray();
+
+        $this->assertEquals($translated['name_translated'], 'Tag name');
+        $this->assertEquals($translated['slug_translated'], 'tag-name');
+    }
+
+    /** @test */
+    public function it_provides_tags_with_name_and_slug_translated_for_alternate_locales()
+    {
+        $tag = Tag::findOrCreate('My tag');
+
+        $locale = 'fr';
+
+        $tag->setTranslation('name', $locale, 'Mon tag');
+        $tag->save();
+
+        $translated = Tag::getTranslated($locale)->first()->toArray();
+
+        $this->assertEquals($translated['name_translated'], 'Mon tag');
+        $this->assertEquals($translated['slug_translated'], 'mon-tag');
+    }
 }


### PR DESCRIPTION
A previous PR added the ability to grab the `name_translated` and `slug_translated` fields from tags but only via a model relationship. This PR will allow users to grab all of the tags with the same fields. 

Should be a solution to #171 

Basically you do 

```$tags = Tag::getTranslated($locale);```

and it will fetch all tags (or with whatever constraints you like) with the `name_translated` and `slug_translated` added, depending on whatever locale you define (defaults to `app()->getLocale()`).