### PR TITLE
Use taggable_type in scopeWithAllTags(*)

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -81,10 +81,8 @@ trait HasTags
         $tags = static::convertToTags($tags, $type);
 
         collect($tags)->each(function ($tag) use ($query) {
-            $query->whereIn("{$this->getTable()}.{$this->getKeyName()}", function ($query) use ($tag) {
-                $query->from('taggables')
-                    ->select('taggables.taggable_id')
-                    ->where('taggables.tag_id', $tag ? $tag->id : 0);
+            $query->whereHas('tags', function (Builder $query) use ($tag) {
+                $query->where('tags.id', $tag ? $tag->id : 0);
             });
         });
 
@@ -113,10 +111,8 @@ trait HasTags
         $tags = static::convertToTagsOfAnyType($tags);
 
         collect($tags)->each(function ($tag) use ($query) {
-            $query->whereIn("{$this->getTable()}.{$this->getKeyName()}", function ($query) use ($tag) {
-                $query->from('taggables')
-                    ->select('taggables.taggable_id')
-                    ->where('taggables.tag_id', $tag ? $tag->id : 0);
+            $query->whereHas('tags', function (Builder $query) use ($tag) {
+                $query->where('tags.id', $tag ? $tag->id : 0);
             });
         });
 


### PR DESCRIPTION
scopeWithAllTags and scopeWithAllTagsOfAnyType does not include the taggable_type which leads to wrong results for the given model.

$query = Filter::withAllTagsOfAnyType(['test']);
dd($query->toSql(), $query->getBindings());

**scopeWithAllTags**

Query before change: 
select * from `filters` where `filters`.`id` in (select `taggables`.`taggable_id` from `taggables` where `taggables`.`tag_id` = ?) and `filters`.`deleted_at` is null

Query after change:
select * from `filters` where exists (select * from `tags` inner join `taggables` on `tags`.`id` = `taggables`.`tag_id` where `filters`.`id` = `taggables`.`taggable_id` and `taggables`.`taggable_type` = ? and `tags`.`id` = ?) and `filters`.`deleted_at` is null

**scopeWithAllTagsOfAnyType**

Query before change:
select * from `filters` where `filters`.`id` in (select `taggables`.`taggable_id` from `taggables` where `taggables`.`tag_id` = ?) and `filters`.`deleted_at` is null

Query after change:
select * from `filters` where exists (select * from `tags` inner join `taggables` on `tags`.`id` = `taggables`.`tag_id` where `filters`.`id` = `taggables`.`taggable_id` and `taggables`.`taggable_type` = ? and `tags`.`id` = ?) and `filters`.`deleted_at` is null