### PR TITLE
Added ability to specify a different connection for the tags and taggables tables

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -7,4 +7,13 @@ return [
      * Defaults to Str::slug (https://laravel.com/docs/5.8/helpers#method-str-slug)
      */
     'slugger' => null,
+
+    /*
+     * If using a different DB connection, specify it here
+     */
+    'storage' => [
+        'database' => [
+            'connection' => env('DB_CONNECTION', 'mysql'),
+        ],
+    ],
 ];

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -12,6 +12,11 @@ trait HasTags
 {
     protected $queuedTags = [];
 
+    public function getConnectionName(): string
+    {
+        return config('tags.storage.database.connection');
+    }
+
     public static function getTagClassName(): string
     {
         return Tag::class;


### PR DESCRIPTION
In many of my projects I use multiple database connections and this minor modification is required in order to make things work with this package.