### PR TITLE
Add findFromSlug and findFromSlugOfAnyType methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ $tag2->order_column; //returns 2
 
 //manipulating the order of tags
 $tag->swapOrder($anotherTag);
+
+//tags can be found by slug
+Tag::findOrCreateFromString('My tag', 'customTagType');
+$tag = Tag::findFromSlugOfAnyType('my-tag'); //returns Tag 'My tag'
+
+//tags can be found by slug and type
+Tag::findOrCreateFromString('My custom tag', 'customType');
+$tag = Tag::findFromSlug('my-custom-tag', 'customType'); //returns Tag 'My custom tag'
 ```
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -80,7 +80,7 @@ class Tag extends Model implements Sortable
     public static function findFromSlug(string $name, string $type = null, string $locale = null)
     {
         $locale = $locale ?? app()->getLocale();
-        
+
         return static::query()
             ->where("slug->{$locale}", $name)
             ->where('type', $type)

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -76,19 +76,21 @@ class Tag extends Model implements Sortable
             ->where("name->{$locale}", $name)
             ->first();
     }
-    
-    
+
     public static function findFromSlug(string $name, string $type = null, string $locale = null)
     {
         $locale = $locale ?? app()->getLocale();
+        
         return static::query()
             ->where("slug->{$locale}", $name)
             ->where('type', $type)
             ->first();
     }
+
     public static function findFromSlugOfAnyType(string $name, string $locale = null)
     {
         $locale = $locale ?? app()->getLocale();
+
         return static::query()
             ->where("slug->{$locale}", $name)
             ->first();

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -76,6 +76,23 @@ class Tag extends Model implements Sortable
             ->where("name->{$locale}", $name)
             ->first();
     }
+    
+    
+    public static function findFromSlug(string $name, string $type = null, string $locale = null)
+    {
+        $locale = $locale ?? app()->getLocale();
+        return static::query()
+            ->where("slug->{$locale}", $name)
+            ->where('type', $type)
+            ->first();
+    }
+    public static function findFromSlugOfAnyType(string $name, string $locale = null)
+    {
+        $locale = $locale ?? app()->getLocale();
+        return static::query()
+            ->where("slug->{$locale}", $name)
+            ->first();
+    }
 
     protected static function findOrCreateFromString(string $name, string $type = null, string $locale = null): self
     {

--- a/tests/TagTest.php
+++ b/tests/TagTest.php
@@ -33,6 +33,26 @@ class TagTest extends TestCase
         $tag = Tag::findOrCreateFromString('string2');
         $this->assertSame(2, $tag->order_column);
     }
+    
+    /** @test */
+    public function it_finds_a_tag_based_on_a_slug()
+    {
+	    Tag::findOrCreate('This is a slug test one', 'slugType');
+	    
+        $tag = Tag::findFromSlug('this-is-a-slug-test-one', 'slugType');
+        
+        $this->assertSame('this-is-a-slug-test-one', $tag->slug);
+    }
+    
+    /** @test */
+    public function it_finds_a_tag_with_type_based_on_a_slug()
+    {
+	    Tag::findOrCreate('This is a slug test two', 'slugType');
+	    
+        $tag = Tag::findFromSlugOfAnyType('this-is-a-slug-test-two');
+        
+        $this->assertSame('this-is-a-slug-test-two', $tag->slug);
+    }
 
     /** @test */
     public function it_automatically_generates_a_slug()

--- a/tests/TagTest.php
+++ b/tests/TagTest.php
@@ -33,24 +33,24 @@ class TagTest extends TestCase
         $tag = Tag::findOrCreateFromString('string2');
         $this->assertSame(2, $tag->order_column);
     }
-    
+
     /** @test */
     public function it_finds_a_tag_based_on_a_slug()
     {
-	    Tag::findOrCreate('This is a slug test one', 'slugType');
-	    
+        Tag::findOrCreate('This is a slug test one', 'slugType');
+
         $tag = Tag::findFromSlug('this-is-a-slug-test-one', 'slugType');
-        
+
         $this->assertSame('this-is-a-slug-test-one', $tag->slug);
     }
-    
+
     /** @test */
     public function it_finds_a_tag_with_type_based_on_a_slug()
     {
-	    Tag::findOrCreate('This is a slug test two', 'slugType');
-	    
+        Tag::findOrCreate('This is a slug test two', 'slugType');
+
         $tag = Tag::findFromSlugOfAnyType('this-is-a-slug-test-two');
-        
+
         $this->assertSame('this-is-a-slug-test-two', $tag->slug);
     }
 


### PR DESCRIPTION
Dear good people of Spatie,

I've added 2 new methods to the Tag model for finding Tags by slug. Currently there's no such possibility and it makes your life easier if you are passing Tag slugs in routes. It also removes unnecessary queries when creating custom route binding parameters.

Tests were also added to see if it's working.

Thank you very much for your time and have a great weekend!

Tom