### PR TITLE
rearrange the import order

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -5,5 +5,4 @@ enabled:
 
 disabled:
   - length_ordered_imports
-  - unused_use
   - single_class_element_per_statement

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,4 +1,9 @@
 preset: laravel
 
+enabled:
+  - alpha_ordered_imports
+
 disabled:
+  - length_ordered_imports
+  - unused_use
   - single_class_element_per_statement

--- a/database/migrations/create_tag_tables.php.stub
+++ b/database/migrations/create_tag_tables.php.stub
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateTagTables extends Migration
 {


### PR DESCRIPTION
I just used this package again for a new Laravel 6.3 project and I noticed that my styleci re-arranged the order of the imports.

Because the new releases of Laravel come with these updated rules, I figured it would only make sense to add them here.