### PR TITLE
Make is so findOrCreateFromString can be overloaded.

### DIFF
--- a/src/Tag.php
+++ b/src/Tag.php
@@ -77,7 +77,7 @@ class Tag extends Model implements Sortable
             ->first();
     }
 
-    protected static function findOrCreateFromString(string $name, string $type = null, string $locale = null): self
+    protected static function findOrCreateFromString(string $name, string $type = null, string $locale = null)
     {
         $locale = $locale ?? app()->getLocale();
 


### PR DESCRIPTION
This package has the option to overload the tag model in the config. When you do so, and extend `Spatie\Tags\Tag` with your own `App\Models\Tag` (for instance) you're not able to overload this method.

<img width="1069" alt="Screen Shot 2019-10-28 at 10 08 25 AM" src="https://user-images.githubusercontent.com/470255/67685649-dad94600-f96b-11e9-85c7-66fd4ac4ea10.png">

Application crashes with fatal.

<img width="324" alt="Screen Shot 2019-10-28 at 10 19 00 AM" src="https://user-images.githubusercontent.com/470255/67686079-88e4f000-f96c-11e9-9313-45e0eda8686c.png">

I'm on Laravel 5.8 and PHP7.2.