### PR TITLE
Remember users put "tags" on $fillable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You'll find the documentation on https://docs.spatie.be/laravel-tags/v2/introduc
 Here are some code examples:
 
 ```php
-//create a model with some tags
+//create a model with some tags, don't forget to put "tags" on $fillable array on referred model
 $newsItem = NewsItem::create([
    'name' => 'The Article Title',
    'tags' => ['first tag', 'second tag'], //tags will be created if they don't exist


### PR DESCRIPTION
Sometimes you may forget to associate that "tags should be placed in the fillable since it is not part of the model itself.
Since in the documentation itself suggests using the method "create", and this if the attribute is not in "fillable" is ignored