### PR TITLE
remove styleci rules enabled by default

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,8 +1,4 @@
 preset: laravel
 
-enabled:
-  - alpha_ordered_imports
-
 disabled:
-  - length_ordered_imports
   - single_class_element_per_statement


### PR DESCRIPTION
Today, StyleCI added these rules to the Laravel preset, so there's no need to specifically declare them here anymore. Sorry 😀