### PR TITLE
make sure each tag is unique on the database level

### DIFF
--- a/database/migrations/create_tag_tables.php.stub
+++ b/database/migrations/create_tag_tables.php.stub
@@ -21,6 +21,8 @@ class CreateTagTables extends Migration
             $table->integer('tag_id')->unsigned();
             $table->morphs('taggable');
 
+            $table->unique(['tag_id', 'taggable_id', 'taggable_type']);
+
             $table->foreign('tag_id')->references('id')->on('tags')->onDelete('cascade');
         });
     }


### PR DESCRIPTION
I just came across a database integrity issue in one of my projects where I had a duplicate tag. Granted, I am catching it now through a validation prior to attaching, but this will make sure that each tag is unique based on the combination of `'tag_id', 'taggable_id', 'taggable_type'`.

I am not sure if this is intended, but in case it's not, here's the fix 👍 