### PR TITLE
change mutator behaviour: use sync instead of attach

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -67,7 +67,7 @@ trait HasTags
             return;
         }
 
-        $this->attachTags($tags);
+        $this->syncTags($tags);
     }
 
     /**

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -83,6 +83,15 @@ class HasTagsTest extends TestCase
     }
 
     /** @test */
+    public function it_can_override_tags_via_the_tags_mutator()
+    {
+        $this->testModel->tags = ['tag1', 'tag2'];
+        $this->testModel->tags = ['tag2', 'tag3', 'tag4'];
+
+        $this->assertCount(3, $this->testModel->tags);
+    }
+
+    /** @test */
     public function it_can_attach_multiple_tags()
     {
         $this->testModel->attachTags(['test1', 'test2']);


### PR DESCRIPTION
Common use case for tagging is when we have form with multiple input like this:
![image](https://user-images.githubusercontent.com/149716/83087627-e7697c80-a0bb-11ea-8949-daedf196f87c.png)

Lets have following scenario:

1. user input `react` `vuejs`, save
2. user edit it with `vuejs`, `jquery`, save

I can simply doing this in controller:
```php
$model->tags = $request->tags;
```

And when calling $model->tags:
**My expectation**: `vuejs` and `jquery`
**Actual behaviour**: `react`, `vuejs`, `jquery`

I don't know if it was intended to call `attachTags` instead of `syncTags` in tags mutator. But, I think `override` (and not addition) is more suitable when we assign value to some attribute.
```php
$foo = [1, 2]; // $foo is [1, 2] 👌🏼
$foo = [2, 3]; // $foo is [1,2,3] 😱
```

This PR fix those problem.