### PR TITLE
Self Relation | Added the funtionality to tag a Tag model.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 vendor
 .env
 .php_cs.cache
+.phpunit.result.cache

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -82,7 +82,8 @@ trait HasTags
 
         collect($tags)->each(function ($tag) use ($query) {
             $query->whereHas('tags', function (Builder $query) use ($tag) {
-                $query->where('tags.id', $tag ? $tag->id : 0);
+                $alias = $this->convertForQueryAlias($query);
+                $query->where("$alias.id", $tag ? $tag->id : 0);
             });
         });
 
@@ -102,7 +103,8 @@ trait HasTags
         return $query->whereHas('tags', function (Builder $query) use ($tags) {
             $tagIds = collect($tags)->pluck('id');
 
-            $query->whereIn('tags.id', $tagIds);
+            $alias = $this->convertForQueryAlias($query);
+            $query->whereIn("$alias.id", $tagIds);
         });
     }
 
@@ -112,7 +114,8 @@ trait HasTags
 
         collect($tags)->each(function ($tag) use ($query) {
             $query->whereHas('tags', function (Builder $query) use ($tag) {
-                $query->where('tags.id', $tag ? $tag->id : 0);
+                $alias = $this->convertForQueryAlias($query);
+                $query->where("$alias.id", $tag ? $tag->id : 0);
             });
         });
 
@@ -126,7 +129,8 @@ trait HasTags
         return $query->whereHas('tags', function (Builder $query) use ($tags) {
             $tagIds = collect($tags)->pluck('id');
 
-            $query->whereIn('tags.id', $tagIds);
+            $alias = $this->convertForQueryAlias($query);
+            $query->whereIn("$alias.id", $tagIds);
         });
     }
 
@@ -309,5 +313,18 @@ trait HasTags
         if ($isUpdated) {
             $this->tags()->touchIfTouching();
         }
+    }
+
+    /**
+     * Check the query "from" statement for an alias and return it if found
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder $query
+     * @return string
+     */
+    protected function convertForQueryAlias(Builder $query): string
+    {
+        return \Illuminate\Support\Str::contains($query->getQuery()->from, [' as ']) ?
+            \Illuminate\Support\Str::after($query->getQuery()->from, ' as ') :
+            $query->getQuery()->from ;
     }
 }

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -12,7 +12,7 @@ use Spatie\Translatable\HasTranslations;
 
 class Tag extends Model implements Sortable
 {
-    use SortableTrait, HasTranslations, HasSlug, HasFactory;
+    use SortableTrait, HasTranslations, HasSlug, HasFactory, HasTags;
 
     public $translatable = ['name', 'slug'];
 

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -307,4 +307,26 @@ class HasTagsTest extends TestCase
         $tagsOfTypeA = $this->testModel->tagsWithType('typeA');
         $this->assertEquals(['tagA1'], $tagsOfTypeA->pluck('name')->toArray());
     }
+
+    /** @test */
+    public function it_is_capable_of_self_relation()
+    {
+        // A.K.A: A tag can tag another tag
+        $tag1 = Tag::firstOrCreate(['name' => 'Tag1']);
+        $tag2 = Tag::firstOrCreate(['name' => 'Tag2']);
+
+        $traits = class_uses_recursive(Tag::class);
+        $this->assertContains('Spatie\Tags\HasTags', $traits);
+
+        $this->assertInstanceOf(MorphToMany::class, $tag1->tags());
+
+        $tag1->attachTag('Tag2');
+
+        $this->assertCount(1, $tag1->tags);
+
+        $this->assertCount(1, Tag::withAllTags(['Tag2'])->get());
+        $this->assertCount(1, Tag::withAnyTags(['Tag2'])->get());
+        $this->assertCount(1, Tag::withAllTagsOfAnyType(['Tag2'])->get());
+        $this->assertCount(1, Tag::withAnyTagsOfAnyType(['Tag2'])->get());
+    }
 }

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -311,7 +311,7 @@ class HasTagsTest extends TestCase
     /** @test */
     public function it_is_capable_of_self_relation()
     {
-        // A.K.A: A tag can tag another tag
+        // tag creating another tag
         $tag1 = Tag::firstOrCreate(['name' => 'Tag1']);
         $tag2 = Tag::firstOrCreate(['name' => 'Tag2']);
 


### PR DESCRIPTION
### Background
I have encountered a scenario where I need to retrieve one subset of tags based off of their relationship to other tags.

I had tried adding the `HasTags` trait to my local extension of the `\Spatie\Tags\Tag` model, but this was insufficient. This is due to how Laravel handles `has` queries when a model relates to itself. 

(see `Illuminate\Database\Eloquent\HasOneOrMany::getRelationExistenceQueryForSelfRelation()`)

In short, because Laravel is building a nested query using the same table twice, it aliases table name in the `FROM` portion of the query like so:

```
tags AS "laravel_reserved_0"
```

---
### The Issue

So if Laravel is dealing with this conflict out of the box, _what actually is the issue?_

It comes down to how the query scopes within the `HasTags` trait have been written. Specifically the reference to `tags.id` within the callback functions used for the `whereHas()` method. Without knowledge of the table alias, it breaks all of the scopes.

---
### Examples

#### Activity Query (Works)

Say I have an `Activity` model that I want to retrieve using the `withAnyTags` scope. 

`Activity::withAnyTags(['TagA'])->get()`

The query this equates to is as follows

```
SELECT * 
FROM `activities` WHERE EXISTS (
	SELECT * 
	FROM `tags` 
	INNER JOIN `taggables` ON `tags`.`id` = `taggables`.`tag_id` 
	WHERE `activities`.`id` = `taggables`.`taggable_id` 
	AND `taggables`.`taggable_type` = "App\Models\Activity"
	AND `tags`.`id` IN (3)
) AND `activities`.`deleted_at` IS NULL;
```

This is a valid query and returns the expected tagged activites

#### Tag Query (Does Not Work)

Now say I have a `Tag` model that I want to retrieve using the `withAnyTags` scope. 

`Tag::withAnyTags(['TagA'])->get()`

The query this equates to is as follows

```
SELECT * 
FROM `tags` WHERE EXISTS (
	SELECT * 
	FROM `tags` AS `laravel_reserved_0` 
	INNER JOIN `taggables` ON `laravel_reserved_0`.`id` = `taggables`.`tag_id` 
	WHERE `tags`.`id` = `taggables`.`taggable_id` 
	AND `taggables`.`taggable_type` = "App\Models\Tag" 
	AND `tags`.`id` IN (3) # <===== `tags` needs to be replaced with the `laravel_reserved_0`
);
```

As you can see, the `tags` table referenced within the nested query is now incorrectly referencing the outer query rather than the alias `laravel_reserved_0` that Laravel has generated.

---

### Proposed Changes

To fix this, i've created a private method on the `HasTags` trait which can identify when Laravel has added an alias to the query. Then within each scope, i've injected this new alias when the `tags` table is referenced.