### PR TITLE
Get all registered tag types

### DIFF
--- a/docs/basic-usage/using-tags.md
+++ b/docs/basic-usage/using-tags.md
@@ -88,3 +88,11 @@ Tag::findOrCreate('two');
 
 Tag::containing('on')->get(); // will return all tags except `two`
 ```
+
+## Getting types
+
+You can fetch a collection of all registered tag types by using the static method `getTypes()`:
+
+```php
+Tag::getTypes();
+```

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -95,11 +95,6 @@ class Tag extends Model implements Sortable
         return $tag;
     }
 
-    /**
-     * Get a list of all registered types.
-     *
-     * @return Collection
-     */
     public static function getTypes(): Collection {
         return static::groupBy('type')->pluck('type');
     }

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -94,6 +94,15 @@ class Tag extends Model implements Sortable
         return $tag;
     }
 
+    /**
+     * Get a list of all registered types.
+     *
+     * @return DbCollection
+     */
+    public static function getTypes(): DbCollection {
+        return static::groupBy('type')->pluck('type');
+    }
+
     public function setAttribute($key, $value)
     {
         if ($key === 'name' && ! is_array($value)) {

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -3,6 +3,7 @@
 namespace Spatie\Tags;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Collection as DbCollection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -97,9 +98,9 @@ class Tag extends Model implements Sortable
     /**
      * Get a list of all registered types.
      *
-     * @return DbCollection
+     * @return Collection
      */
-    public static function getTypes(): DbCollection {
+    public static function getTypes(): Collection {
         return static::groupBy('type')->pluck('type');
     }
 

--- a/tests/TagTest.php
+++ b/tests/TagTest.php
@@ -183,4 +183,18 @@ class TagTest extends TestCase
 
         $this->assertEquals('new name', $tag->name);
     }
+
+    /** @test */
+    public function it_gets_all_tag_types() {
+        Tag::findOrCreate('foo', 'type1');
+        Tag::findOrCreate('bar', 'type1');
+        Tag::findOrCreate('baz', 'type2');
+        Tag::findOrCreate('qux', 'type2');
+
+        $types = Tag::getTypes();
+
+        $this->assertCount(2, $types);
+        $this->assertEquals('type1', $types[0]);
+        $this->assertEquals('type2', $types[1]);
+    }
 }


### PR DESCRIPTION
Simple method to quickly retrieve a collection of all tag types:

```php
Tag::getTypes();
// Collection ['type1', 'type2']
```