### PR TITLE
Fix wrong creation method

### DIFF
--- a/docs/basic-usage/using-tags.md
+++ b/docs/basic-usage/using-tags.md
@@ -81,10 +81,10 @@ $tag->delete();
 You can find all tags containing a specific value with the `containing` scope.
 
 ```php
-Tag::create('one');
-Tag::create('another-one');
-Tag::create('another-ONE-with-different-casing');
-Tag::create('two');
+Tag::findOrCreate('one');
+Tag::findOrCreate('another-one');
+Tag::findOrCreate('another-ONE-with-different-casing');
+Tag::findOrCreate('two');
 
 Tag::containing('on')->get(); // will return all tags except `two`
 ```


### PR DESCRIPTION
Docs uses `create` but passing an string as parameter, it should be `findOrCreate`, was so confused since default Tag class does not have an override for the default Eloquent create method.