### PR TITLE
ADD tag_model config variable

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -7,4 +7,9 @@ return [
      * Defaults to Str::slug (https://laravel.com/docs/5.8/helpers#method-str-slug)
      */
     'slugger' => null,
+
+    /*
+     * The fully qualified class name of the tag model.
+     */
+    'tag_model' => Spatie\Tags\Tag::class,
 ];

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -14,7 +14,7 @@ trait HasTags
 
     public static function getTagClassName(): string
     {
-        return Tag::class;
+        return config('tags.tag_model', Tag::class);
     }
 
     public static function bootHasTags()


### PR DESCRIPTION
I'm adding this config variable to add the ability to customize the default Tag model (i.e. adding the tenant_id attribute and its related global scopes).
The only option right now to override the default Tag model is by overriding the `HasTags` `getTagClassName` method, but I think the solution I'm suggesting is a bit more consistent!