### PR TITLE
New major version: v4 (PHP8+)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                php: [8.0,7.4]
+                php: [8.0]
                 laravel: [8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+.idea
 build
 composer.lock
 vendor
 .env
 .php_cs.cache
+.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-tags` will be documented in this file
 
+## 4.0.0 - unreleased
+
+- drop support for all PHP versions below 8.0
+
 ## 3.1.0 - 2021-03-01
 
 -add `tag_model` config variable (#301)

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php": "^8.0",
         "laravel/framework": "^8.0",
         "spatie/eloquent-sortable": "^3.5",
+        "spatie/laravel-package-tools": "^1.4",
         "spatie/laravel-translatable": "^4.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "laravel/framework": "^8.0",
         "spatie/eloquent-sortable": "^3.5",
         "spatie/laravel-translatable": "^4.1"

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -3,4 +3,4 @@ title: Requirements
 weight: 3
 ---
 
-This package requires Laravel 8 or higher, PHP 7.4 or higher and a database that supports `json` fields such as MySQL 5.7.8 or higher.
+This package requires Laravel 8 or higher, PHP 8 or higher and a database that supports `json` fields such as MySQL 5.7.8 or higher.

--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -18,7 +18,7 @@ trait HasSlug
     {
         $slugger = config('tags.slugger');
 
-        $slugger = $slugger ?: '\Illuminate\Support\Str::slug';
+        $slugger ??= '\Illuminate\Support\Str::slug';
 
         return call_user_func($slugger, $this->getTranslation('name', $locale));
     }

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -41,10 +41,7 @@ trait HasTags
             ->ordered();
     }
 
-    /**
-     * @param string $locale
-     */
-    public function tagsTranslated($locale = null): MorphToMany
+    public function tagsTranslated(string|null $locale = null): MorphToMany
     {
         $locale = ! is_null($locale) ? $locale : app()->getLocale();
 
@@ -56,10 +53,7 @@ trait HasTags
             ->ordered();
     }
 
-    /**
-     * @param string|array|\ArrayAccess|\Spatie\Tags\Tag $tags
-     */
-    public function setTagsAttribute($tags)
+    public function setTagsAttribute(string|array|\ArrayAccess|Tag $tags)
     {
         if (! $this->exists) {
             $this->queuedTags = $tags;
@@ -70,32 +64,20 @@ trait HasTags
         $this->syncTags($tags);
     }
 
-    /**
-     * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param array|\ArrayAccess|\Spatie\Tags\Tag $tags
-     *
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public function scopeWithAllTags(Builder $query, $tags, string $type = null): Builder
+    public function scopeWithAllTags(Builder $query, array|\ArrayAccess|Tag $tags, string $type = null): Builder
     {
         $tags = static::convertToTags($tags, $type);
 
         collect($tags)->each(function ($tag) use ($query) {
             $query->whereHas('tags', function (Builder $query) use ($tag) {
-                $query->where('tags.id', $tag ? $tag->id : 0);
+                $query->where('tags.id', $tag->id ?? 0);
             });
         });
 
         return $query;
     }
 
-    /**
-     * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param array|\ArrayAccess|\Spatie\Tags\Tag $tags
-     *
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public function scopeWithAnyTags(Builder $query, $tags, string $type = null): Builder
+    public function scopeWithAnyTags(Builder $query, array|\ArrayAccess|Tag $tags, string $type = null): Builder
     {
         $tags = static::convertToTags($tags, $type);
 
@@ -137,12 +119,7 @@ trait HasTags
         });
     }
 
-    /**
-     * @param array|\ArrayAccess|\Spatie\Tags\Tag $tags
-     * @param string|null $type
-     * @return $this
-     */
-    public function attachTags($tags, string $type = null)
+    public function attachTags(array|\ArrayAccess|Tag $tags, string $type = null): static
     {
         $className = static::getTagClassName();
 
@@ -153,24 +130,12 @@ trait HasTags
         return $this;
     }
 
-    /**
-     * @param string|\Spatie\Tags\Tag $tag
-     *
-     * @param string|null $type
-     * @return $this
-     */
-    public function attachTag($tag, string $type = null)
+    public function attachTag(string|Tag $tag, string|null $type = null)
     {
         return $this->attachTags([$tag], $type);
     }
 
-    /**
-     * @param array|\ArrayAccess $tags
-     *
-     * @param string|null $type
-     * @return $this
-     */
-    public function detachTags($tags, string $type = null)
+    public function detachTags(array|\ArrayAccess $tags, string|null $type = null): static
     {
         $tags = static::convertToTags($tags, $type);
 
@@ -183,23 +148,12 @@ trait HasTags
         return $this;
     }
 
-    /**
-     * @param string|\Spatie\Tags\Tag $tag
-     *
-     * @param string|null $type
-     * @return $this
-     */
-    public function detachTag($tag, string $type = null)
+    public function detachTag(string|Tag $tag, string|null $type = null): static
     {
         return $this->detachTags([$tag], $type);
     }
 
-    /**
-     * @param array|\ArrayAccess $tags
-     *
-     * @return $this
-     */
-    public function syncTags($tags)
+    public function syncTags(array|\ArrayAccess $tags): static
     {
         $className = static::getTagClassName();
 
@@ -210,13 +164,7 @@ trait HasTags
         return $this;
     }
 
-    /**
-     * @param array|\ArrayAccess $tags
-     * @param string|null $type
-     *
-     * @return $this
-     */
-    public function syncTagsWithType($tags, string $type = null)
+    public function syncTagsWithType(array|\ArrayAccess $tags, string|null $type = null): static
     {
         $className = static::getTagClassName();
 
@@ -264,7 +212,7 @@ trait HasTags
      * @param string|null $type
      * @param bool $detaching
      */
-    protected function syncTagIds($ids, string $type = null, $detaching = true)
+    protected function syncTagIds($ids, string|null $type = null, $detaching = true): void
     {
         $isUpdated = false;
 

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -35,7 +35,7 @@ class Tag extends Model implements Sortable
         return $query->whereRaw('lower('.$this->getQuery()->getGrammar()->wrap('name->'.$locale).') like ?', ['%'.mb_strtolower($name).'%']);
     }
 
-    public static function findOrCreate(string|array|\ArrayAccess $values, string|null $type = null, string|null $locale = null): Tag|static
+    public static function findOrCreate(string|array|\ArrayAccess $values, string|null $type = null, string|null $locale = null): Collection|Tag|static
     {
         $tags = collect($values)->map(function ($value) use ($type, $locale) {
             if ($value instanceof self) {

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -15,7 +15,7 @@ class Tag extends Model implements Sortable
 {
     use SortableTrait, HasTranslations, HasSlug, HasFactory;
 
-    public $translatable = ['name', 'slug'];
+    public array $translatable = ['name', 'slug'];
 
     public $guarded = [];
 
@@ -35,14 +35,7 @@ class Tag extends Model implements Sortable
         return $query->whereRaw('lower('.$this->getQuery()->getGrammar()->wrap('name->'.$locale).') like ?', ['%'.mb_strtolower($name).'%']);
     }
 
-    /**
-     * @param string|array|\ArrayAccess $values
-     * @param string|null $type
-     * @param string|null $locale
-     *
-     * @return \Spatie\Tags\Tag|static
-     */
-    public static function findOrCreate($values, string $type = null, string $locale = null)
+    public static function findOrCreate(string|array|\ArrayAccess $values, string|null $type = null, string|null $locale = null): Tag|static
     {
         $tags = collect($values)->map(function ($value) use ($type, $locale) {
             if ($value instanceof self) {

--- a/src/TagsServiceProvider.php
+++ b/src/TagsServiceProvider.php
@@ -2,23 +2,16 @@
 
 namespace Spatie\Tags;
 
-use Illuminate\Support\ServiceProvider;
+use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\PackageServiceProvider;
 
-class TagsServiceProvider extends ServiceProvider
+class TagsServiceProvider extends PackageServiceProvider
 {
-    public function boot()
+    public function configurePackage(Package $package): void
     {
-        if ($this->app->runningInConsole()) {
-            if (! class_exists('CreateTagTables')) {
-                $timestamp = date('Y_m_d_His', time());
-                $this->publishes([
-                    __DIR__.'/../database/migrations/create_tag_tables.php.stub' => database_path('migrations/'.$timestamp.'_create_tag_tables.php'),
-                ], 'migrations');
-            }
-
-            $this->publishes([
-                __DIR__.'/../config/tags.php' => config_path('tags.php'),
-            ], 'config');
-        }
+        $package
+            ->name('laravel-tags')
+            ->hasConfigFile()
+            ->hasMigration('create_tag_tables');
     }
 }


### PR DESCRIPTION
This PR is for a new major package version _(v4)_, and requires PHP 8.0+.

Specifically, this PR:
- Introduces a PHP `^8.0` version constraint in `composer.json`
- Implements `spatie/laravel-package-tools` in the service provider for much cleaner code
- Converts most PHPDoc types to PHP8 union types _(where appropriate)_
- Updates the github action workflow to only run tests on PHP 8

This resolves #302.