### PR TITLE
correct config provider with missing C

### DIFF
--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -22,7 +22,7 @@ php artisan migrate
 
 You can optionally publish the config file with:
 ```bash
-php artisan vendor:publish --provider="Spatie\Tags\TagsServiceProvider" --tag="tags-onfig"
+php artisan vendor:publish --provider="Spatie\Tags\TagsServiceProvider" --tag="tags-config"
 ```
 
 This is the contents of the published config file:


### PR DESCRIPTION
I noticed there was a typo on the setup docs, so this should correct it.

the tags-config was missing the c (previous: tags-onfig)