### PR TITLE
Typo fix - Publishing migrations

### DIFF
--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -11,7 +11,7 @@ composer require spatie/laravel-tags
 
 You can publish the migration with:
 ```bash
-php artisan vendor:publish --provider="Spatie\Tags\TagsServiceProvider" --tag="tags-migrations"
+php artisan vendor:publish --provider="Spatie\Tags\TagsServiceProvider" --tag="migrations"
 ```
 
 After the migration has been published you can create the `tags` and `taggables` tables by running the migrations:


### PR DESCRIPTION
I just noticed that I got "Unable to locate publishable resources."  while following Installation instructions.
Hereby a little fix regarding that command.

Might fix #334