### PR TITLE
Add find method on Tag class

### DIFF
--- a/docs/basic-usage/using-tags.md
+++ b/docs/basic-usage/using-tags.md
@@ -46,7 +46,7 @@ $yourModel->detachTag('tag 1');
 $yourModel->detachTags(['tag 2', 'tag 3']);
 
 //using an instance of \Spatie\Tags\Tag
-$yourModel->detach(\Spatie\Tags\Tag::Find('tag4'));
+$yourModel->detach(\Spatie\Tags\Tag::find('tag4'));
 ```
 
 ## Syncing tags

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -60,6 +60,22 @@ class Tag extends Model implements Sortable
         return static::withType($type)->ordered()->get();
     }
 
+    public static function find(
+        string | array | ArrayAccess $values,
+        string | null $type = null,
+        string | null $locale = null,
+    ): Collection | Tag | static {
+        $tags = collect($values)->map(function ($value) use ($type, $locale) {
+            if ($value instanceof self) {
+                return $value;
+            }
+
+            return static::findFromString($value, $type, $locale);
+        });
+
+        return is_string($values) ? $tags->first() : $tags;
+    }
+
     public static function findFromString(string $name, string $type = null, string $locale = null)
     {
         $locale = $locale ?? app()->getLocale();

--- a/tests/TagTest.php
+++ b/tests/TagTest.php
@@ -198,4 +198,16 @@ class TagTest extends TestCase
         $this->assertEquals('type1', $types[0]);
         $this->assertEquals('type2', $types[1]);
     }
+
+    /** @test */
+    public function it_finds_tags()
+    {
+        Tag::findOrCreate(['foo', 'bar']);
+
+        $fooTag = Tag::findFromString('foo');
+        $barTag = Tag::find('bar');
+
+        $this->assertEquals('foo', $fooTag->name);
+        $this->assertEquals('bar', $barTag->name);
+    }
 }


### PR DESCRIPTION
This implements the find method mentioned in the docs and is a shortcut to `::findFromString()` replicating the same functionality as `::findOrCreate()`