### PR TITLE
Get the tag model table name when syncing tags

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -233,7 +233,7 @@ trait HasTags
                     '=',
                     $tagModel->getTable() . '.' . $tagModel->getKeyName()
                 )
-                    ->where('tags.type', $type);
+                    ->where($tagModel->getTable() . '.type', $type);
             })
             ->pluck('tag_id')
             ->all();


### PR DESCRIPTION
In the `syncTagIds()` method the tag model is used to receive the table name. Except for one place, where the table name was hardcoded.