### PR TITLE
Added functionality to get a distinct collection of Tags attached to a model based on taggable_type

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -44,6 +44,24 @@ trait HasTags
             ->ordered();
     }
 
+    public function modelTags(): Collection
+    {
+        $tagModel = $this->tags()->getRelated();
+
+        return $this->tags()
+            ->newPivotStatement()
+            ->where('taggable_type', $this->getMorphClass())
+            ->join(
+                    $tagModel->getTable(),
+                    'taggables.tag_id',
+                    '=',
+                    $tagModel->getTable() . '.' . $tagModel->getKeyName()
+            )
+            ->select($tagModel->getTable().'.*')
+            ->distinct()
+            ->get();
+    }
+
     public function tagsTranslated(string | null $locale = null): MorphToMany
     {
         $locale = ! is_null($locale) ? $locale : app()->getLocale();

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -20,6 +20,20 @@ class HasTagsTest extends TestCase
     }
 
     /** @test */
+    public function it_has_model_tags()
+    {
+        $anotherModel = TestModel::create(['name' => 'other']);
+
+        $anotherModel->attachTag('Biz');
+        $anotherModel->attachTag('Zap');
+
+        $this->testModel->attachTag('Foo');
+        $this->testModel->attachTag('Bar');
+
+        $this->assertCount(4, (new TestModel)->modelTags());
+    }
+
+    /** @test */
     public function it_provides_a_tags_relation()
     {
         $this->assertInstanceOf(MorphToMany::class, $this->testModel->tags());


### PR DESCRIPTION
# Background
Sometimes I find myself needing to populate a list of all the tags that are attached to the specific model. The `tags()` method will only return the tags attached to a single model instance.  The `modelTags()` method will get the class name of the model and return a collection of all the distinct tags attached to to any model with the same taggable_type.

The query looks like: 
```
SELECT DISTINCT
	"tags".*
FROM
	"taggables"
	INNER JOIN "tags" ON "taggables"."tag_id" = "tags"."id"
WHERE
	"taggable_type" = "App\\Model\\User"
```

# Examples

Attaching tags to two different models:
```
$model1 = Model::create(['name' => 'default']);
$model1->attachTag(['foo', 'bar']);

$model2 = Model::create(['name' => 'other']);
$model2->attachTag(['biz', 'baz']);

$model1->tags() // returns foo, bar
$models2->tags() // returns biz, baz

$model1->modelTags() // returns foo, bar, biz, baz
(new Model)->modelTags() // returns foo, bar, biz, baz
```

I may be wrong but I don't believe `spatie/laravel-tags` has this functionality to return a list of tags attached to a particular taggable_type.  I have found this method to be helpful in my day to day work.  Open to changing the name to fit in your naming scheme.  

PS - New to pull requests, if you need any more information or fixes please let me know!  Thank you the consideration :)