### PR TITLE
Ignore the `phpunit.xml` file by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 .env
 .php-cs-fixer.cache
 .phpunit.result.cache
+phpunit.xml

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ If you've found a bug regarding security please mail [freek@spatie.be](mailto:fr
 
 ## Testing
 
-1. Copy `.env.example` to `.env` and fill in your database credentials.
+1. Copy `phpunit.xml.dist` to `phpunit.xml` and fill in your database credentials.
 2. Run `composer test`.
 
 ### Changelog


### PR DESCRIPTION
We use the phpunit.xml.dist so we can overwrite phpunit configuration
locally. But the file is not ignored by git. This makes it possible to
accidentally push your local version of the configuration file to the
repository. Ignoring this file will prevent that from happening.

Just a small PR, but I like to split up my PR's instead of pushing a big change in one time.