### PR TITLE
Adding a static function for current locale to the tag

### DIFF
--- a/docs/advanced-usage/disabling-translations.md
+++ b/docs/advanced-usage/disabling-translations.md
@@ -1,0 +1,45 @@
+---
+title: Disabling translations
+weight: 2
+---
+
+In some cases, like setting tags by page visitors in a multi-language environment, the translations are not needed and can even cause "empty" tags. Tag's information like name and description shall contain the same information regardless the current locale, during creating and displaying the tag.
+
+To achieve this behavior you can force the Tag class to use a specific locale rather than getting the current application's locale. First create an own Tag's model and override the function `getLocale()`. 
+
+```php
+
+namespace App\Models;
+
+use Spatie\Tags\Tag as SpatieTag;
+
+class YourTag extends SpatieTag
+{
+    public static function getLocale()
+    {
+        return 'en';
+    }
+}
+
+```
+
+Then don't forget to change the tag class in tags config (config/tags.php):
+
+```php
+
+return [
+
+    /*
+     * The given function generates a URL friendly "slug" from the tag name property before saving it.
+     * Defaults to Str::slug (https://laravel.com/docs/master/helpers#method-str-slug)
+     */
+    'slugger' => null,
+
+    /*
+     * The fully qualified class name of the tag model.
+     */
+    'tag_model' => App\Models\YourTag::class,
+];
+
+
+```

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -46,7 +46,7 @@ trait HasTags
 
     public function tagsTranslated(string | null $locale = null): MorphToMany
     {
-        $locale = ! is_null($locale) ? $locale : app()->getLocale();
+        $locale = ! is_null($locale) ? $locale : self::getTagClassName()::getLocale();
 
         return $this
             ->morphToMany(self::getTagClassName(), 'taggable')

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -23,6 +23,11 @@ class Tag extends Model implements Sortable
 
     public $guarded = [];
 
+    public static function getLocale()
+    {
+        return app()->getLocale();
+    }
+
     public function scopeWithType(Builder $query, string $type = null): Builder
     {
         if (is_null($type)) {
@@ -34,7 +39,7 @@ class Tag extends Model implements Sortable
 
     public function scopeContaining(Builder $query, string $name, $locale = null): Builder
     {
-        $locale = $locale ?? app()->getLocale();
+        $locale = $locale ?? static::getLocale();
 
         return $query->whereRaw('lower(' . $this->getQuery()->getGrammar()->wrap('name->' . $locale) . ') like ?', ['%' . mb_strtolower($name) . '%']);
     }
@@ -62,7 +67,7 @@ class Tag extends Model implements Sortable
 
     public static function findFromString(string $name, string $type = null, string $locale = null)
     {
-        $locale = $locale ?? app()->getLocale();
+        $locale = $locale ?? static::getLocale();
 
         return static::query()
             ->where("name->{$locale}", $name)
@@ -72,7 +77,7 @@ class Tag extends Model implements Sortable
 
     public static function findFromStringOfAnyType(string $name, string $locale = null)
     {
-        $locale = $locale ?? app()->getLocale();
+        $locale = $locale ?? static::getLocale();
 
         return static::query()
             ->where("name->{$locale}", $name)
@@ -81,7 +86,7 @@ class Tag extends Model implements Sortable
 
     protected static function findOrCreateFromString(string $name, string $type = null, string $locale = null)
     {
-        $locale = $locale ?? app()->getLocale();
+        $locale = $locale ?? static::getLocale();
 
         $tag = static::findFromString($name, $type, $locale);
 
@@ -103,7 +108,7 @@ class Tag extends Model implements Sortable
     public function setAttribute($key, $value)
     {
         if (in_array($key, $this->translatable) && ! is_array($value)) {
-            return $this->setTranslation($key, app()->getLocale(), $value);
+            return $this->setTranslation($key, static::getLocale(), $value);
         }
 
         return parent::setAttribute($key, $value);

--- a/tests/CustomStaticLocaleTest.php
+++ b/tests/CustomStaticLocaleTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\Translatable\Test;
+
+use Spatie\Tags\Test\TestCase;
+use Spatie\Tags\Test\TestClasses\TestCustomTagStaticLocaleModel;
+
+class CustomStaticLocaleTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->assertCount(0, TestCustomTagStaticLocaleModel::all());
+    }
+
+    /** @test */
+    public function it_can_use_static_locale()
+    {
+        app()->setLocale('es');
+
+        $tag = TestCustomTagStaticLocaleModel::findOrCreateFromString('string');
+        
+        $staticLocale = 'en';
+
+        $translated = TestCustomTagStaticLocaleModel::where('name', 'LIKE', '%' . $staticLocale . '%')->first()->toArray();
+
+        $this->assertEquals('string', $translated['name'][$staticLocale]);
+        $this->assertCount(1, TestCustomTagStaticLocaleModel::all());
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -54,5 +54,14 @@ abstract class TestCase extends Orchestra
             $table->integer('order_column')->nullable();
             $table->timestamps();
         });
+
+        Schema::create('custom_tags_static_locale', function (Blueprint $table) {
+            $table->id();
+            $table->json('name');
+            $table->json('slug');
+            $table->string('type')->nullable();
+            $table->integer('order_column')->nullable();
+            $table->timestamps();
+        });        
     }
 }

--- a/tests/TestClasses/TestCustomTagStaticLocaleModel.php
+++ b/tests/TestClasses/TestCustomTagStaticLocaleModel.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\Tags\Test\TestClasses;
+
+use Spatie\Tags\Tag;
+
+class TestCustomTagStaticLocaleModel extends Tag
+{
+    public $table = 'custom_tags_static_locale';
+
+    public static function getLocale()
+    {
+        return 'en';
+    }
+}


### PR DESCRIPTION
The current locale is not get by app()->getLocale() but by a static function. With this change it is possible to implement custom logic of getting the locale inside of custom Tag. It can also be used to set the locale to a fixed value to "deactivate" the translation functionality.