### PR TITLE
Make convertToTags() method $values arg  support Tag instance

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -187,6 +187,10 @@ trait HasTags
 
     protected static function convertToTags($values, $type = null, $locale = null)
     {
+        if ($values instanceof Tag) {
+            $values = [$values];
+        }
+        
         return collect($values)->map(function ($value) use ($type, $locale) {
             if ($value instanceof Tag) {
                 if (isset($type) && $value->type != $type) {

--- a/tests/HasTagsScopesTest.php
+++ b/tests/HasTagsScopesTest.php
@@ -77,6 +77,16 @@ class HasTagsScopesTest extends TestCase
     }
 
     /** @test */
+    public function it_provides_as_scope_to_get_all_models_that_have_the_given_tag_instance()
+    {
+        $tagModel = Tag::findOrCreate('tagB');
+
+        $testModels = TestModel::withAllTags($tagModel)->get();
+
+        $this->assertEquals(['model2', 'model3'], $testModels->pluck('name')->toArray());
+    }
+
+    /** @test */
     public function it_provides_as_scope_to_get_all_models_that_have_any_of_the_given_tags_with_type()
     {
         $testModels = TestModel::withAnyTags(['tagE'], 'typedTag')->get();


### PR DESCRIPTION
Just as ` scopeWithAllTags() ` method, it's ` $tags ` arg can be `Tag` instance. But if we use Tag instance, `convertToTags()` method will go wrong, because ` collect ` function will convert `Tag` to array, and will query each attribute value for `Tag`. That is wrong.

For simplicity, I think we can handle it this way. 