### PR TITLE
Add support for spatie/laravel-translatable:^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "laravel/framework": "^8.67|^9.0",
         "spatie/eloquent-sortable": "^3.10|^4.0",
         "spatie/laravel-package-tools": "^1.4",
-        "spatie/laravel-translatable": "^4.6|^5.0"
+        "spatie/laravel-translatable": "^4.6|^5.0|^6.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.13|^7.0",


### PR DESCRIPTION
This PR adds support for the latest version of `spatie/laravel-translatable`