### PR TITLE
Added support for strings and corresponding tests

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
 trait HasTags
@@ -69,7 +70,7 @@ trait HasTags
 
     public function scopeWithAllTags(
         Builder $query,
-        array | ArrayAccess | Tag $tags,
+        string | array | ArrayAccess | Tag $tags,
         string $type = null,
     ): Builder {
         $tags = static::convertToTags($tags, $type);
@@ -85,7 +86,7 @@ trait HasTags
 
     public function scopeWithAnyTags(
         Builder $query,
-        array | ArrayAccess | Tag $tags,
+        string | array | ArrayAccess | Tag $tags,
         string $type = null,
     ): Builder {
         $tags = static::convertToTags($tags, $type);
@@ -162,8 +163,10 @@ trait HasTags
         return $this->detachTags([$tag], $type);
     }
 
-    public function syncTags(array | ArrayAccess $tags): static
+    public function syncTags(string | array | ArrayAccess $tags): static
     {
+        $tags = Arr::wrap($tags);
+
         $className = static::getTagClassName();
 
         $tags = collect($className::findOrCreate($tags));

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -79,7 +79,7 @@ class HasTagsTest extends TestCase
     /** @test */
     public function it_can_attach_a_tag_via_the_tags_mutator()
     {
-        $this->testModel->tags = ['tag1'];
+        $this->testModel->tags = 'tag1';
 
         $this->assertCount(1, $this->testModel->tags);
     }
@@ -219,6 +219,56 @@ class HasTagsTest extends TestCase
     }
 
     /** @test */
+    public function it_provides_a_scope_to_get_all_models_that_have_a_given_tag()
+    {
+        TestModel::create([
+            'name' => 'model1',
+            'tags' => ['tagA'],
+        ]);
+
+        TestModel::create([
+            'name' => 'model2',
+            'tags' => ['tagA', 'tagB'],
+        ]);
+
+        TestModel::create([
+            'name' => 'model3',
+            'tags' => ['tagA', 'tagB', 'tagC'],
+        ]);
+
+        $testModels = TestModel::withAnyTags('tagB');
+
+        $this->assertEquals(['model2', 'model3'], $testModels->pluck('name')->toArray());
+
+        $testModels = TestModel::withAllTags('tagB');
+
+        $this->assertEquals(['model2', 'model3'], $testModels->pluck('name')->toArray());
+    }
+
+    /** @test */
+    public function it_provides_a_scope_to_get_all_models_that_have_all_given_tags()
+    {
+        TestModel::create([
+            'name' => 'model1',
+            'tags' => ['tagA'],
+        ]);
+
+        TestModel::create([
+            'name' => 'model2',
+            'tags' => ['tagA', 'tagB'],
+        ]);
+
+        TestModel::create([
+            'name' => 'model3',
+            'tags' => ['tagA', 'tagB', 'tagC'],
+        ]);
+
+        $testModels = TestModel::withAllTags(['tagB', 'tagC']);
+
+        $this->assertEquals(['model3'], $testModels->pluck('name')->toArray());
+    }
+
+    /** @test */
     public function it_provides_a_scope_to_get_all_models_that_have_any_of_the_given_tag_instances()
     {
         $tag = Tag::findOrCreate('tagA', 'typeA');
@@ -237,7 +287,7 @@ class HasTagsTest extends TestCase
     {
         $this->testModel->attachTags(['tag1', 'tag2', 'tag3']);
 
-        $this->testModel->syncTags(['tag3']);
+        $this->testModel->syncTags('tag3');
 
         $this->assertEquals(['tag3'], $this->testModel->tags->pluck('name')->toArray());
     }


### PR DESCRIPTION
Scopes `withAllTags` and `withAnyTags` used to work with strings, it was just an issue with function argument typing. Added test cases.

At the same time I found out that attribute mutator `setTagsAttribute` was already accepting a tag as string and passing the argument to `syncTags` which, however, didn't support that. Fixed the test case of adding a single tag by mutator by removing the array brackets and making it fail, then solved by array wrapping the parameter.