### PR TITLE
Added Tests for newly added hasTags and hasTag methods

### DIFF
--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -187,12 +187,25 @@ class HasTagsTest extends TestCase
     public function it_can_get_all_attached_tags_of_a_certain_type()
     {
         $this->testModel->tags()->attach(Tag::findOrCreate('test', 'type1'));
-        $this->testModel->tags()->attach(Tag::findOrCreate('test2', 'type2'));
 
         $tagsOfType2 = $this->testModel->tagsWithType('type2');
 
         $this->assertCount(1, $tagsOfType2);
         $this->assertEquals('type2', $tagsOfType2->first()->type);
+    }
+    
+    /** @test */
+    public function it_can_check_if_model_contains_specific_tags()
+    {
+        $this->testModel->tags()->attach(['test1', 'test2']);
+        $this->assertTrue($this->hasTags(['test1', 'test2']);
+    }
+                          
+    /** @test */
+    public function it_can_check_if_model_contains_specific_tag()
+    {
+        $this->testModel->tags()->attach(['test']);
+        $this->assertTrue($this->hasTag('test1');
     }
 
     /** @test */


### PR DESCRIPTION
ps: I accidentally deleted the line `$this->testModel->tags()->attach(Tag::findOrCreate('test2', 'type2'));` on line 190 :-(. Please help me put it back :-). Thanks