### PR TITLE
Update using-tags.md typo by changing "Find" to "find"

### DIFF
--- a/docs/basic-usage/using-tags.md
+++ b/docs/basic-usage/using-tags.md
@@ -43,7 +43,7 @@ $yourModel->detachTag('tag 1');
 $yourModel->detachTags(['tag 2', 'tag 3']);
 
 //using an instance of \Spatie\Tags\Tag
-$yourModel->detach(\Spatie\Tags\Tag::Find('tag4'));
+$yourModel->detach(\Spatie\Tags\Tag::find('tag4'));
 ```
 
 ## Syncing tags


### PR DESCRIPTION
Small change

Even tho $yourModel->detach(\Spatie\Tags\Tag::Find('tag4')); fully works as PHP doesn't care about case-sensitive I think you guys meant for it to be "find" with lower-case "f"