### PR TITLE
Update .gitattributes to decrease package installed size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,10 +2,13 @@
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
 # Ignore all test and documentation with "export-ignore".
-/.gitattributes     export-ignore
-/.gitignore         export-ignore
-/.travis.yml        export-ignore
-/phpunit.xml.dist   export-ignore
-/.scrutinizer.yml   export-ignore
-/tests              export-ignore
-/.env               export-ignore
+/.github                  export-ignore
+/.gitattributes           export-ignore
+/.gitignore               export-ignore
+/phpunit.xml.dist         export-ignore
+/docs                     export-ignore
+/tests                    export-ignore
+/.editorconfig            export-ignore
+/.php-cs-fixer.dist.php   export-ignore
+/CHANGELOG.md             export-ignore
+/UPGRADING.md             export-ignore


### PR DESCRIPTION
I notice the `docs` folder are include in the vendor dir.

![image](https://user-images.githubusercontent.com/20186786/171923034-71d639b4-d881-4e43-a3c1-ddfabfe83463.png)

So i made this PR to update the .gitattributes file to ignore more files/folder. I follow the [laravel-permission](https://github.com/spatie/laravel-permission/blob/main/.gitattributes) .gitattributes template.

Before `1.2MB`; After `41K`.

![image](https://user-images.githubusercontent.com/20186786/171923508-dc2647e8-e9a6-4fd9-a5d4-ba68478b5249.png)
