### PR TITLE
Add without tags scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ NewsItem::withAnyTags(['first tag', 'second tag'])->get();
 // retrieve models that have all of the given tags
 NewsItem::withAllTags(['first tag', 'second tag'])->get();
 
+// retrieve models that doesn't have any of the given tags
+NewsItem::withoutTags(['first tag', 'second tag'])->get();
+
 // translating a tag
 $tag = Tag::findOrCreate('my tag');
 $tag->setTranslation('name', 'fr', 'mon tag');

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ NewsItem::withAnyTags(['first tag', 'second tag'])->get();
 // retrieve models that have all of the given tags
 NewsItem::withAllTags(['first tag', 'second tag'])->get();
 
-// retrieve models that doesn't have any of the given tags
+// retrieve models that don't have any of the given tags
 NewsItem::withoutTags(['first tag', 'second tag'])->get();
 
 // translating a tag

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -99,6 +99,21 @@ trait HasTags
             });
     }
 
+    public function scopeWithoutTags(
+        Builder $query,
+        string | array | ArrayAccess | Tag $tags,
+        string $type = null
+    ): Builder {
+        $tags = static::convertToTags($tags, $type);
+
+        return $query
+            ->whereDoesntHave('tags', function (Builder $query) use ($tags) {
+                $tagIds = collect($tags)->pluck('id');
+
+                $query->whereIn('tags.id', $tagIds);
+            });
+    }
+
     public function scopeWithAllTagsOfAnyType(Builder $query, $tags): Builder
     {
         $tags = static::convertToTagsOfAnyType($tags);

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -238,7 +238,7 @@ it('provides a scope to get all models that have all given tags', function () {
 });
 
 
-it('provides a scope to get all models that doesnt have any of the given tags', function () {
+it('provides a scope to get all models that do not have any of the given tags', function () {
     $this->testModel->attachTag('tagA');
 
     TestModel::create([

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -238,6 +238,29 @@ it('provides a scope to get all models that have all given tags', function () {
 });
 
 
+it('provides a scope to get all models that doesnt have any of the given tags', function () {
+    $this->testModel->attachTag('tagA');
+
+    TestModel::create([
+        'name' => 'model1',
+        'tags' => ['tagA', 'tagB'],
+    ]);
+
+    TestModel::create([
+        'name' => 'model2',
+        'tags' => ['tagA', 'tagB', 'tagC'],
+    ]);
+
+    $testModels = TestModel::withoutTags(['tagC']);
+
+    expect($testModels->pluck('name')->toArray())->toEqual(['default', 'model1']);
+
+    $testModels = TestModel::withoutTags(['tagC', 'tagB']);
+
+    expect($testModels->pluck('name')->toArray())->toEqual(['default']);
+});
+
+
 it('provides a scope to get all models that have any of the given tag instances', function () {
     $tag = Tag::findOrCreate('tagA', 'typeA');
 


### PR DESCRIPTION
This PR is just trying to add one new scope called without tags, to add the possibility to get models that are not tagged by a provided list of tags.

```php
NewsItem::withoutTags(['first tag', 'second tag'])->get();
```

I'm open to questions or suggestions. :)

Thanks!

