### PR TITLE
Add PHP 8.2 to tests workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                php: [8.0, 8.1]
+                php: [8.0, 8.1, 8.2]
                 laravel: [9.*, 8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
@@ -33,7 +33,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^8.0",
         "laravel/framework": "^8.67|^9.0",
+        "nesbot/carbon": "^2.63",
         "spatie/eloquent-sortable": "^3.10|^4.0",
         "spatie/laravel-package-tools": "^1.4",
         "spatie/laravel-translatable": "^4.6|^5.0|^6.0"


### PR DESCRIPTION
This PR adds PHP 8.2 to the tests workflow, and bumps the `action/checkout` version to v3.

It also adds the `nesbot/carbon` dependency with a minimum version of `2.63`, which is required for PHP 8.2 support.