### PR TITLE
Match locale in example

### DIFF
--- a/docs/advanced-usage/using-another-default-locale.md
+++ b/docs/advanced-usage/using-another-default-locale.md
@@ -18,7 +18,7 @@ class YourTag extends SpatieTag
 {
     public static function getLocale(): string
     {
-        return 'en';
+        return 'nl';
     }
 }
 ```


### PR DESCRIPTION
The example mentions the Dutch language, but the code returns English

Avoids possible confusion just in case of blind copy-paste ^-^