### PR TITLE
Add find tag by slug functions in Tag model

### DIFF
--- a/src/Tag.php
+++ b/src/Tag.php
@@ -84,6 +84,25 @@ class Tag extends Model implements Sortable
             ->get();
     }
 
+    public static function findFromSlug(string $slug, string $type = null, string $locale = null)
+    {
+        $locale = $locale ?? static::getLocale();
+
+        return static::query()
+            ->where("slug->{$locale}", $slug)
+            ->where('type', $type)
+            ->first();
+    }
+
+    public static function findFromSlugOfAnyType(string $slug, string $locale = null)
+    {
+        $locale = $locale ?? static::getLocale();
+
+        return static::query()
+            ->where("slug->{$locale}", $slug)
+            ->get();
+    }
+
     protected static function findOrCreateFromString(string $name, string $type = null, string $locale = null)
     {
         $locale = $locale ?? static::getLocale();


### PR DESCRIPTION
Hello, Spatie team!

First of all, thanks for making this awesome package. ❤️

I'm working on a project and yesterday I installed this package. I need to find tag by slug.

I added ```findFromSlug()``` and ```findFromSlugOfAnyType()``` functions in Tag model to find a single tag by slug. I hope these functions will be helpful.

## Usage
```php
$tag_name = "Laravel Eloquent";
$tag_slug = "laravel-eloquent";
$tag_type = "article";

// to retrieve a certain tag by slug
$tag = Tag::findFromSlug($tag_slug, $tag_type);

// to retrieve a collection of tags by slug with various types
$tags = Tag::findFromSlugOfAnyType($tag_slug);
```