### PR TITLE
Return slugs in find methods

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,14 +10,19 @@ jobs:
         strategy:
             matrix:
                 php: [8.0, 8.1, 8.2]
-                laravel: [9.*, 8.*]
+                laravel: [10.*, 9.*, 8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
                 include:
+                    - laravel: 10.*
+                      testbench: 8.*
                     - laravel: 9.*
                       testbench: 7.*
                     - laravel: 8.*
                       testbench: 6.*
+                exclude:
+                    - laravel: 10.*
+                      php: 8.0
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to `laravel-tags` will be documented in this file
 
+## 4.3.6 - 2023-01-24
+
+- support Laravel 10
+
+### What's Changed
+
+- Add PHP 8.2 to tests workflow by @patinthehat in https://github.com/spatie/laravel-tags/pull/429
+- Add Dependabot Automation by @patinthehat in https://github.com/spatie/laravel-tags/pull/430
+- Match locale in example by @CaddyDz in https://github.com/spatie/laravel-tags/pull/435
+- Bump actions/checkout from 2 to 3 by @dependabot in https://github.com/spatie/laravel-tags/pull/432
+- Switch to anonymous migration and void return type for up method by @ziming in https://github.com/spatie/laravel-tags/pull/440
+- Method for reversing migrations by @eimantaaas in https://github.com/spatie/laravel-tags/pull/442
+
+### New Contributors
+
+- @CaddyDz made their first contribution in https://github.com/spatie/laravel-tags/pull/435
+- @dependabot made their first contribution in https://github.com/spatie/laravel-tags/pull/432
+- @ziming made their first contribution in https://github.com/spatie/laravel-tags/pull/440
+- @eimantaaas made their first contribution in https://github.com/spatie/laravel-tags/pull/442
+
+**Full Changelog**: https://github.com/spatie/laravel-tags/compare/4.3.5...4.3.6
+
 ## 4.3.5 - 2022-11-19
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-
-[<img src="https://github-ads.s3.eu-central-1.amazonaws.com/support-ukraine.svg?t=1" />](https://supportukrainenow.org)
-
 # Add tags and taggable behaviour to a Laravel app
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/spatie/laravel-tags.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-tags)

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
     ],
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^8.67|^9.0",
+        "laravel/framework": "^8.67|^9.0|^10.0",
         "nesbot/carbon": "^2.63",
         "spatie/eloquent-sortable": "^3.10|^4.0",
         "spatie/laravel-package-tools": "^1.4",
         "spatie/laravel-translatable": "^4.6|^5.0|^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.13|^7.0",
+        "orchestra/testbench": "^6.13|^7.0|^8.0",
         "pestphp/pest": "^1.22",
         "phpunit/phpunit": "^9.5.2"
     },

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -70,8 +70,11 @@ class Tag extends Model implements Sortable
         $locale = $locale ?? static::getLocale();
 
         return static::query()
-            ->where("name->{$locale}", $name)
             ->where('type', $type)
+            ->where(function($query) use ($name, $locale) {
+                $query->where("name->{$locale}", $name)
+                    ->orWhere("slug->{$locale}", $name);
+            })
             ->first();
     }
 
@@ -81,6 +84,7 @@ class Tag extends Model implements Sortable
 
         return static::query()
             ->where("name->{$locale}", $name)
+            ->orWhere("slug->{$locale}", $name)
             ->get();
     }
 

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -71,7 +71,6 @@ class Tag extends Model implements Sortable
 
         return static::query()
             ->where("name->{$locale}", $name)
-            ->orWhere("slug->{$locale}", $name)
             ->where('type', $type)
             ->first();
     }
@@ -82,7 +81,6 @@ class Tag extends Model implements Sortable
 
         return static::query()
             ->where("name->{$locale}", $name)
-            ->orWhere("slug->{$locale}", $name)
             ->get();
     }
 

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -64,13 +64,14 @@ class Tag extends Model implements Sortable
     {
         return static::withType($type)->get();
     }
-
+    
     public static function findFromString(string $name, string $type = null, string $locale = null)
     {
         $locale = $locale ?? static::getLocale();
 
         return static::query()
             ->where("name->{$locale}", $name)
+            ->orWhere("slug->{$locale}", $name)
             ->where('type', $type)
             ->first();
     }
@@ -81,6 +82,7 @@ class Tag extends Model implements Sortable
 
         return static::query()
             ->where("name->{$locale}", $name)
+            ->orWhere("slug->{$locale}", $name)
             ->get();
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\Tags\Test;
 
-use CreateTagTables;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\TestCase as Orchestra;
@@ -31,9 +30,9 @@ abstract class TestCase extends Orchestra
     {
         Schema::dropAllTables();
 
-        include_once __DIR__.'/../database/migrations/create_tag_tables.php.stub';
+        $migration = include __DIR__.'/../database/migrations/create_tag_tables.php.stub';
 
-        (new CreateTagTables())->up();
+        $migration->up();
 
         Schema::create('test_models', function (Blueprint $table) {
             $table->increments('id');


### PR DESCRIPTION
https://github.com/spatie/laravel-tags/discussions/437

I assume if a "name" is in slug format, that the slug will be the same as the name?!

Assumption aside, I don't see any side effects for methods like `findOrCreateFromString` which call these changed functions.