### PR TITLE
Add isUsed() to Tag model

### DIFF
--- a/docs/basic-usage/using-tags.md
+++ b/docs/basic-usage/using-tags.md
@@ -99,3 +99,10 @@ You can fetch a collection of all registered tag types by using the static metho
 ```php
 Tag::getTypes();
 ```
+## Check is a tag is used
+
+You can check if a tag is used by any model wich use the HasTags trait.
+
+```php
+$tag->isUsed();
+```

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Collection as DbCollection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Spatie\EloquentSortable\Sortable;
 use Spatie\EloquentSortable\SortableTrait;
 use Spatie\Translatable\HasTranslations;
@@ -109,6 +110,11 @@ class Tag extends Model implements Sortable
         return static::groupBy('type')->pluck('type');
     }
 
+    public function isUsed(): bool
+    {
+        return DB::table('taggables')->where('tag_id', $this->id)->exists();
+    }
+    
     public function setAttribute($key, $value)
     {
         if (in_array($key, $this->translatable) && ! is_array($value)) {


### PR DESCRIPTION
Add isUsed() to check if a tag is used in database.

I use this method to check that a tag is unused and in this case delete it from the database.

![image](https://user-images.githubusercontent.com/2249236/224507029-c5647a1b-9f15-4a47-a87e-f3af4c8cde59.png)

For exemple when I click on the cross in livewire : 
```php
public function removeTag($tagName)
    {
        $tag = Tag::findFromString($tagName);
        $this->company->detachTag($tagName);
        $this->company->refresh();
        if(!$tag->isUsed()) {
            $tag->delete();
        }
    }
```