### PR TITLE
Add the ability to configure a custom Taggables model class

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -19,5 +19,10 @@ return [
     'taggable' => [
         'table_name' => 'taggables',
         'morph_name' => 'taggable',
+
+        /*
+         * The fully qualified class name of the pivot model.
+         */
+        'class_name' => Illuminate\Database\Eloquent\Relations\MorphPivot::class,
     ]
 ];

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -29,6 +29,11 @@ trait HasTags
         return config('tags.taggable.table_name', 'taggables');
     }
 
+    public function getPivotModelClassName(): string
+    {
+        return config('tags.taggable.class_name');
+    }
+
     public static function bootHasTags()
     {
         static::created(function (Model $taggableModel) {
@@ -52,6 +57,7 @@ trait HasTags
     {
         return $this
             ->morphToMany(self::getTagClassName(), $this->getTaggableMorphName())
+            ->using($this->getPivotModelClassName())
             ->ordered();
     }
 
@@ -61,6 +67,7 @@ trait HasTags
 
         return $this
             ->morphToMany(self::getTagClassName(), $this->getTaggableMorphName())
+            ->using($this->getPivotModelClassName())
             ->select('*')
             ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(name, '$.\"{$locale}\"')) as name_translated")
             ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(slug, '$.\"{$locale}\"')) as slug_translated")


### PR DESCRIPTION
This change allows the use of an own taggables class.  Thus, for example, events can be easily registered on the taggables.