### PR TITLE
Define class MorphPivot as default for the 'tags.taggable.class_name' config getter.

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
@@ -31,7 +32,7 @@ trait HasTags
 
     public function getPivotModelClassName(): string
     {
-        return config('tags.taggable.class_name');
+        return config('tags.taggable.class_name', MorphPivot::class);
     }
 
     public static function bootHasTags()


### PR DESCRIPTION
Fixes Isse #472