### PR TITLE
fix: set public visibility for findOrCreateFromString

### DIFF
--- a/src/Tag.php
+++ b/src/Tag.php
@@ -88,7 +88,7 @@ class Tag extends Model implements Sortable
             ->get();
     }
 
-    protected static function findOrCreateFromString(string $name, string $type = null, string $locale = null)
+    public static function findOrCreateFromString(string $name, string $type = null, string $locale = null)
     {
         $locale = $locale ?? static::getLocale();
 


### PR DESCRIPTION
While working on a project I used `findOrCreateFromString()` and PHPStan complained about it

> Call to protected static method findOrCreateFromString() of class Spatie\Tags\Tag.  
