### PR TITLE
fix: Fixing issue when using a different table to store pivot data

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -57,7 +57,7 @@ trait HasTags
     public function tags(): MorphToMany
     {
         return $this
-            ->morphToMany(self::getTagClassName(), $this->getTaggableMorphName())
+            ->morphToMany(self::getTagClassName(), $this->getTaggableMorphName(), $this->getTaggableTableName())
             ->using($this->getPivotModelClassName())
             ->ordered();
     }
@@ -67,7 +67,7 @@ trait HasTags
         $locale = ! is_null($locale) ? $locale : self::getTagClassName()::getLocale();
 
         return $this
-            ->morphToMany(self::getTagClassName(), $this->getTaggableMorphName())
+            ->morphToMany(self::getTagClassName(), $this->getTaggableMorphName(), $this->getTaggableTableName())
             ->using($this->getPivotModelClassName())
             ->select('*')
             ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(name, '$.\"{$locale}\"')) as name_translated")


### PR DESCRIPTION
This fixes an issue when you use a different table name to store pivot data between tags and taggables.

Let's say you use "lorem_tags" to store tags, and "lorem_tag_model" to store pivot data, and on pivot table you have "tag_id, model_id, model_type", when you set on config:

```
    'taggable' => [
        'table_name' => 'lorem_tag_model',
        'morph_name' => 'model',
    ]
```

It'll look for the models table to check the pivot instead of lorem_tag_model