### PR TITLE
Allow Carbon v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.0",
         "laravel/framework": "^8.67|^9.0|^10.0|^11.0",
-        "nesbot/carbon": "^2.63",
+        "nesbot/carbon": "^2.63|^3.0",
         "spatie/eloquent-sortable": "^3.10|^4.0",
         "spatie/laravel-package-tools": "^1.4",
         "spatie/laravel-translatable": "^4.6|^5.0|^6.0"


### PR DESCRIPTION
Laravel 11 also requires Carbon v3, so this will let you not pass `-W` to `composer require`