### PR TITLE
bugfix: fixes the syncWithType method to avoid deleting tags without …

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -260,22 +260,20 @@ trait HasTags
     {
         $isUpdated = false;
 
+        $tagModel = $this->tags()->getRelated();
+
         // Get a list of tag_ids for all current tags
         $current = $this->tags()
             ->newPivotStatement()
             ->where($this->getTaggableMorphName() . '_id', $this->getKey())
             ->where($this->getTaggableMorphName() . '_type', $this->getMorphClass())
-            ->when($type !== null, function ($query) use ($type) {
-                $tagModel = $this->tags()->getRelated();
-
-                return $query->join(
-                    $tagModel->getTable(),
-                    $this->getTaggableTableName() . '.tag_id',
-                    '=',
-                    $tagModel->getTable() . '.' . $tagModel->getKeyName()
-                )
-                    ->where($tagModel->getTable() . '.type', $type);
-            })
+            ->join(
+                $tagModel->getTable(),
+                'taggables.tag_id',
+                '=',
+                $tagModel->getTable() . '.' . $tagModel->getKeyName()
+            )
+            ->where($tagModel->getTable() . '.type', $type)
             ->pluck('tag_id')
             ->all();
 

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -312,6 +312,19 @@ it('can sync tags with different types', function () {
     expect($tagsOfTypeB->pluck('name')->toArray())->toEqual(['tagB1', 'tagB2']);
 });
 
+it('can sync tags without a type and not affect tags with a type', function () {
+    $this->testModel->syncTagsWithType(['test1', 'test2'], 'testType');
+
+    $this->testModel->syncTagsWithType(['test3']);
+
+    expect($this->testModel->tags->pluck('name')->toArray())->toEqual(['test1', 'test2', 'test3']);
+
+    expect($this->testModel->tags->where('name', '=', 'test1')->first()->type)->toEqual('testType');
+
+    expect($this->testModel->tags->where('name', '=', 'test2')->first()->type)->toEqual('testType');
+
+    expect($this->testModel->tags->where('name', '=', 'test3')->first()->type)->toBeNull();
+});
 
 it('can sync same tag type with different models with same foreign id', function () {
     $this->testModel->syncTagsWithType(['tagA1', 'tagA2', 'tagA3'], 'typeA');


### PR DESCRIPTION
When you had sync between tags with a type and without a type, it would delete the tags with a type, if you sync tags without a type, for example: 

(Tag 1, typeTest)
(Tag 2, typeTest)

If you sync (Tag 3, null), it would delete Tag 1 and Tag 2. 