### PR TITLE
Fixed links to documentation pages

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -5,7 +5,7 @@ weight: 1
 
 This package offers taggable behaviour for your models. After the package is installed the only thing you have to do is to add the `HasTags` trait to an Eloquent model to make it taggable. 
 
-We didn't stop with the regular tagging capabilities you find in every package. Laravel Tags comes with batteries included. Out of the box it has support for [translating tags](/laravel-tags/v4/advanced-usage/adding-translations), [multiple tag types](/laravel-tags/v4/advanced-usage/using-types) and [sorting capabilities](/laravel-tags/v4/advanced-usage/sorting-tags).
+We didn't stop with the regular tagging capabilities you find in every package. Laravel Tags comes with batteries included. Out of the box it has support for [translating tags](https://spatie.be/docs/laravel-tags/v4/advanced-usage/adding-translations), [multiple tag types](https://spatie.be/docs/laravel-tags/v4/advanced-usage/using-types) and [sorting capabilities](https://spatie.be/docs/laravel-tags/v4/advanced-usage/sorting-tags).
 
 Here are some code examples:
 


### PR DESCRIPTION
These links throw a 404 error because the `/docs/` section is missing.

I made these changes by looking at other documentation links in other packages, for example:
https://github.com/spatie/laravel-pdf/blob/8c6d39429532b2be4cfbc81b52764bb8707dcbdd/docs/advanced-usage/generating-pdfs-on-aws-lambda.md?plain=1#L21