### PR TITLE
Add "hasTag" method to check if the model has a certain tag

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -302,4 +302,13 @@ trait HasTags
             $this->tags()->touchIfTouching();
         }
     }
+
+    public function hasTag($tag, string $type = null): bool
+    {
+        return $this->tags
+            ->when($type !== null, fn ($query) => $query->where('type', $type))
+            ->contains(function ($modelTag) use ($tag) {
+                return $modelTag->name === $tag || $modelTag->id === $tag;
+            });
+    }
 }

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -349,3 +349,27 @@ it('can sync tags with same name', function () {
     $tagsOfTypeA = $this->testModel->tagsWithType('typeA');
     expect($tagsOfTypeA->pluck('name')->toArray())->toEqual(['tagA1']);
 });
+
+it('can check if it has a tag', function () {
+    $model = TestModel::create(['name' => 'test model']);
+    $tag = Tag::findOrCreate('test-tag');
+    $anotherTag = Tag::findOrCreate('another-tag');
+
+    $model->attachTag($tag);
+
+    $this->assertTrue($model->hasTag('test-tag'));
+    $this->assertTrue($model->hasTag($tag->id));
+    $this->assertFalse($model->hasTag('non-existing-tag'));
+    $this->assertFalse($model->hasTag($anotherTag->id));
+});
+
+it('can check if it has a tag with type', function () {
+    $model = TestModel::create(['name' => 'test model']);
+    $tag = Tag::findOrCreate('test-tag', 'type1');
+    $sameNameDifferentType = Tag::findOrCreate('test-tag', 'type2');
+
+    $model->attachTag($tag);
+
+    $this->assertTrue($model->hasTag('test-tag', 'type1'));
+    $this->assertFalse($model->hasTag('test-tag', 'type2'));
+});

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -351,25 +351,23 @@ it('can sync tags with same name', function () {
 });
 
 it('can check if it has a tag', function () {
-    $model = TestModel::create(['name' => 'test model']);
     $tag = Tag::findOrCreate('test-tag');
     $anotherTag = Tag::findOrCreate('another-tag');
 
-    $model->attachTag($tag);
+    $this->testModel->attachTag($tag);
 
-    $this->assertTrue($model->hasTag('test-tag'));
-    $this->assertTrue($model->hasTag($tag->id));
-    $this->assertFalse($model->hasTag('non-existing-tag'));
-    $this->assertFalse($model->hasTag($anotherTag->id));
+    expect($this->testModel->hasTag('test-tag'))->toBeTrue();
+    expect($this->testModel->hasTag($tag->id))->toBeTrue();
+    expect($this->testModel->hasTag('non-existing-tag'))->toBeFalse();
+    expect($this->testModel->hasTag($anotherTag->id))->toBeFalse();
 });
 
 it('can check if it has a tag with type', function () {
-    $model = TestModel::create(['name' => 'test model']);
     $tag = Tag::findOrCreate('test-tag', 'type1');
     $sameNameDifferentType = Tag::findOrCreate('test-tag', 'type2');
 
-    $model->attachTag($tag);
+    $this->testModel->attachTag($tag);
 
-    $this->assertTrue($model->hasTag('test-tag', 'type1'));
-    $this->assertFalse($model->hasTag('test-tag', 'type2'));
+    expect($this->testModel->hasTag('test-tag', 'type1'))->toBeTrue();
+    expect($this->testModel->hasTag('test-tag', 'type2'))->toBeFalse();
 });


### PR DESCRIPTION
I have been building this functionality in three projects now, so I think it might be something others could find usable as well.

You can check if a model has a certain tag by its name, or by its ID.

In my case I am currently developing a portal for runners where we list races of different distances, and each race can offer multiple distances. For certain distances we should display some extra options. So we put the distances as tags on the Race model. Now we need a way to check if this race has for example "Marathon", then we should display the map of aid stations, which is not the case for 5k races or shorter.