### PR TITLE
Document the `hasTag` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ $tag2->order_column; //returns 2
 
 // manipulating the order of tags
 $tag->swapOrder($anotherTag);
+
+// checking if a model has a tag
+$newsItem->hasTag('first tag');
+$newsItem->hasTag('first tag', 'some_type');
 ```
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).

--- a/docs/basic-usage/using-tags.md
+++ b/docs/basic-usage/using-tags.md
@@ -99,3 +99,19 @@ You can fetch a collection of all registered tag types by using the static metho
 ```php
 Tag::getTypes();
 ```
+
+## Checking if a model has a tag
+
+You can check if a model has a specific tag using the `hasTag` method:
+
+```php
+$yourModel->hasTag('tag 1'); // returns true if the model has the tag
+$yourModel->hasTag('non-existing tag'); // returns false if the model does not have the tag
+```
+
+You can also check if a model has a tag with a specific type:
+
+```php
+$yourModel->hasTag('tag 1', 'some_type'); // returns true if the model has the tag with the specified type
+$yourModel->hasTag('tag 1', 'non-existing type'); // returns false if the model does not have the tag with the specified type
+```

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -302,4 +302,13 @@ trait HasTags
             $this->tags()->touchIfTouching();
         }
     }
+
+    public function hasTag($tag, string $type = null): bool
+    {
+        return $this->tags
+            ->when($type !== null, fn ($query) => $query->where('type', $type))
+            ->contains(function ($modelTag) use ($tag) {
+                return $modelTag->name === $tag || $modelTag->id === $tag;
+            });
+    }
 }

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -349,3 +349,25 @@ it('can sync tags with same name', function () {
     $tagsOfTypeA = $this->testModel->tagsWithType('typeA');
     expect($tagsOfTypeA->pluck('name')->toArray())->toEqual(['tagA1']);
 });
+
+it('can check if it has a tag', function () {
+    $tag = Tag::findOrCreate('test-tag');
+    $anotherTag = Tag::findOrCreate('another-tag');
+
+    $this->testModel->attachTag($tag);
+
+    expect($this->testModel->hasTag('test-tag'))->toBeTrue();
+    expect($this->testModel->hasTag($tag->id))->toBeTrue();
+    expect($this->testModel->hasTag('non-existing-tag'))->toBeFalse();
+    expect($this->testModel->hasTag($anotherTag->id))->toBeFalse();
+});
+
+it('can check if it has a tag with type', function () {
+    $tag = Tag::findOrCreate('test-tag', 'type1');
+    $sameNameDifferentType = Tag::findOrCreate('test-tag', 'type2');
+
+    $this->testModel->attachTag($tag);
+
+    expect($this->testModel->hasTag('test-tag', 'type1'))->toBeTrue();
+    expect($this->testModel->hasTag('test-tag', 'type2'))->toBeFalse();
+});


### PR DESCRIPTION
For #517

* **README.md**
  - Add a section to document the `hasTag` method
  - Include examples of how to use the `hasTag` method

* **docs/basic-usage/using-tags.md**
  - Add a section to document the `hasTag` method
  - Include examples of how to use the `hasTag` method