### PR TITLE
Fix dynamic taggable table name

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -269,7 +269,7 @@ trait HasTags
             ->where($this->getTaggableMorphName() . '_type', $this->getMorphClass())
             ->join(
                 $tagModel->getTable(),
-                'taggables.tag_id',
+                $this->getTaggableTableName() . '.tag_id',
                 '=',
                 $tagModel->getTable() . '.' . $tagModel->getKeyName()
             )


### PR DESCRIPTION
Hello,

Going from 4.6.1 to 4.7.0 broke the `syncTagIds` method by changing `$this->getTaggableTableName() . '.tag_id',` to forced `'taggables.tag_id',`

I'm using a custom taggable table name, resulting in this SQL error:

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'taggables.tag_id' in 'on clause' (Connection: mysql, SQL: select `tag_id` from `spatie_taggables` inner join `spatie_tags` on `taggables`.`tag_id` = `spatie_tags`.`id` [...]
```

config:
```php
    /*
     * The name of the table associated with the taggable morph relation.
     */
    'taggable' => [
        'table_name' => 'spatie_taggables',
        'morph_name' => 'taggable',
    ],
```

Changing it back to `$this->getTaggableTableName() . '.tag_id',` restored functionality.

Let me know if you need anything else.