### PR TITLE
Fixes for HasTags.php - PHP 8.4 implicit nullable type declaration 

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -89,7 +89,7 @@ trait HasTags
     public function scopeWithAllTags(
         Builder $query,
         string | array | ArrayAccess | Tag $tags,
-        string $type = null,
+        ?string $type = null,
     ): Builder {
         $tags = static::convertToTags($tags, $type);
 
@@ -105,7 +105,7 @@ trait HasTags
     public function scopeWithAnyTags(
         Builder $query,
         string | array | ArrayAccess | Tag $tags,
-        string $type = null,
+        ?string $type = null,
     ): Builder {
         $tags = static::convertToTags($tags, $type);
 
@@ -120,7 +120,7 @@ trait HasTags
     public function scopeWithoutTags(
         Builder $query,
         string | array | ArrayAccess | Tag $tags,
-        string $type = null
+        ?string $type = null
     ): Builder {
         $tags = static::convertToTags($tags, $type);
 
@@ -159,12 +159,12 @@ trait HasTags
         );
     }
 
-    public function tagsWithType(string $type = null): Collection
+    public function tagsWithType(?string $type = null): Collection
     {
         return $this->tags->filter(fn (Tag $tag) => $tag->type === $type);
     }
 
-    public function attachTags(array | ArrayAccess | Tag $tags, string $type = null): static
+    public function attachTags(array | ArrayAccess | Tag $tags, ?string $type = null): static
     {
         $className = static::getTagClassName();
 
@@ -300,7 +300,7 @@ trait HasTags
         }
     }
 
-    public function hasTag($tag, string $type = null): bool
+    public function hasTag($tag, ?string $type = null): bool
     {
         return $this->tags
             ->when($type !== null, fn ($query) => $query->where('type', $type))


### PR DESCRIPTION
Recommended changes: 
https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated#change

Without changes, throws many WARNING errors:

WARNING: Spatie\Tags\HasTags::scopeWithAllTags(): Implicitly marking parameter $type as nullable is deprecated, the explicit nullable type must be used instead in vendor/spatie/laravel-tags/src/HasTags.php on line 89  