### PR TITLE
Allow custom tag table name and primary key for scoped queries

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -13,6 +13,11 @@ return [
      */
     'tag_model' => Spatie\Tags\Tag::class,
 
+    'tags' => [
+        'table_name' => 'tags',
+        'primary_key' => 'id',
+    ],
+
     /*
      * The name of the table associated with the taggable morph relation.
      */

--- a/config/tags.php
+++ b/config/tags.php
@@ -13,11 +13,6 @@ return [
      */
     'tag_model' => Spatie\Tags\Tag::class,
 
-    'tags' => [
-        'table_name' => 'tags',
-        'primary_key' => 'id',
-    ],
-
     /*
      * The name of the table associated with the taggable morph relation.
      */

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -23,7 +23,7 @@ trait HasTags
     public static function getTagTableName(): string
     {
         $tagInstance = new (self::getTagClassName());
-        return config('tags.tags.table_name', $tagInstance->getTable());
+        return $tagInstance->getTable();
     }
 
     public static function getTagTableKeyQuery(): string
@@ -34,7 +34,7 @@ trait HasTags
     public static function getTagPrimaryKey(): string
     {
         $tagInstance = new (self::getTagClassName());
-        return config('tags.tags.primary_key', $tagInstance->getKeyName());
+        return $tagInstance->getKeyName();
     }
 
     public function getTaggableMorphName(): string

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -20,6 +20,23 @@ trait HasTags
         return config('tags.tag_model', Tag::class);
     }
 
+    public static function getTagTableName(): string
+    {
+        $tagInstance = new (self::getTagClassName());
+        return config('tags.tags.table_name', $tagInstance->getTable());
+    }
+
+    public static function getTagTableKeyQuery(): string
+    {
+        return self::getTagTableName() . '.' . self::getTagPrimaryKey();
+    }
+
+    public static function getTagPrimaryKey(): string
+    {
+        $tagInstance = new (self::getTagClassName());
+        return config('tags.tags.primary_key', $tagInstance->getKeyName());
+    }
+
     public function getTaggableMorphName(): string
     {
         return config('tags.taggable.morph_name', 'taggable');
@@ -95,7 +112,7 @@ trait HasTags
 
         collect($tags)->each(function ($tag) use ($query) {
             $query->whereHas('tags', function (Builder $query) use ($tag) {
-                $query->where('tags.id', $tag->id ?? 0);
+                $query->where(self::getTagTableKeyQuery(), $tag->id ?? 0);
             });
         });
 
@@ -113,7 +130,7 @@ trait HasTags
             ->whereHas('tags', function (Builder $query) use ($tags) {
                 $tagIds = collect($tags)->pluck('id');
 
-                $query->whereIn('tags.id', $tagIds);
+                $query->whereIn(self::getTagTableKeyQuery(), $tagIds);
             });
     }
 
@@ -128,7 +145,7 @@ trait HasTags
             ->whereDoesntHave('tags', function (Builder $query) use ($tags) {
                 $tagIds = collect($tags)->pluck('id');
 
-                $query->whereIn('tags.id', $tagIds);
+                $query->whereIn(self::getTagTableKeyQuery(), $tagIds);
             });
     }
 
@@ -140,7 +157,7 @@ trait HasTags
             ->each(function ($tag) use ($query) {
                 $query->whereHas(
                     'tags',
-                    fn (Builder $query) => $query->where('tags.id', $tag ? $tag->id : 0)
+                    fn (Builder $query) => $query->where(self::getTagTableKeyQuery(), $tag ? $tag->id : 0)
                 );
             });
 
@@ -155,7 +172,7 @@ trait HasTags
 
         return $query->whereHas(
             'tags',
-            fn (Builder $query) => $query->whereIn('tags.id', $tagIds)
+            fn (Builder $query) => $query->whereIn(self::getTagTableKeyQuery(), $tagIds)
         );
     }
 

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -23,10 +23,11 @@ trait HasTags
     public static function getTagTableName(): string
     {
         $tagInstance = new (self::getTagClassName());
+        
         return $tagInstance->getTable();
     }
 
-    public static function getTagTableKeyQuery(): string
+    public static function getTagTablePrimaryKeyName(): string
     {
         return self::getTagTableName() . '.' . self::getTagPrimaryKey();
     }
@@ -112,7 +113,7 @@ trait HasTags
 
         collect($tags)->each(function ($tag) use ($query) {
             $query->whereHas('tags', function (Builder $query) use ($tag) {
-                $query->where(self::getTagTableKeyQuery(), $tag->id ?? 0);
+                $query->where(self::getTagTablePrimaryKeyName(), $tag->id ?? 0);
             });
         });
 
@@ -130,7 +131,7 @@ trait HasTags
             ->whereHas('tags', function (Builder $query) use ($tags) {
                 $tagIds = collect($tags)->pluck('id');
 
-                $query->whereIn(self::getTagTableKeyQuery(), $tagIds);
+                $query->whereIn(self::getTagTablePrimaryKeyName(), $tagIds);
             });
     }
 
@@ -145,7 +146,7 @@ trait HasTags
             ->whereDoesntHave('tags', function (Builder $query) use ($tags) {
                 $tagIds = collect($tags)->pluck('id');
 
-                $query->whereIn(self::getTagTableKeyQuery(), $tagIds);
+                $query->whereIn(self::getTagTablePrimaryKeyName(), $tagIds);
             });
     }
 
@@ -157,7 +158,7 @@ trait HasTags
             ->each(function ($tag) use ($query) {
                 $query->whereHas(
                     'tags',
-                    fn (Builder $query) => $query->where(self::getTagTableKeyQuery(), $tag ? $tag->id : 0)
+                    fn (Builder $query) => $query->where(self::getTagTablePrimaryKeyName(), $tag ? $tag->id : 0)
                 );
             });
 
@@ -172,7 +173,7 @@ trait HasTags
 
         return $query->whereHas(
             'tags',
-            fn (Builder $query) => $query->whereIn(self::getTagTableKeyQuery(), $tagIds)
+            fn (Builder $query) => $query->whereIn(self::getTagTablePrimaryKeyName(), $tagIds)
         );
     }
 


### PR DESCRIPTION
Scoped queries in the `HasTags` trait previously hard-coded the `tags.id` value for the `where` or `whereIn` clauses. This PR addresses the issue by creating new methods to get the Tag class's table name and primary key name from the defined class name in the config file, or by defaulting to `Tag::class`.

Tests were not updated, because existing tests cover use cases.