### PR TITLE
Laravel 12 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,10 +10,12 @@ jobs:
         strategy:
             matrix:
                 php: [8.0, 8.1, 8.2, 8.3]
-                laravel: [11.*, 10.*, 9.*, 8.*]
+                laravel: [12.*, 11.*, 10.*, 9.*, 8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
                 include:
+                    - laravel: 12.*
+                      testbench: 10.*
                     - laravel: 11.*
                       testbench: 9.*
                     - laravel: 10.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                php: [8.1, 8.2, 8.3]
+                php: [8.1, 8.2, 8.3, 8.4]
                 laravel: [12.*, 11.*, 10.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                php: [8.0, 8.1, 8.2, 8.3]
+                php: [8.1, 8.2, 8.3]
                 laravel: [12.*, 11.*, 10.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
@@ -22,9 +22,7 @@ jobs:
                       testbench: 8.*
                 exclude:
                     - laravel: 11.*
-                      php: [8.1, 8.0]
-                    - laravel: 10.*
-                      php: 8.0
+                      php: 8.1
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
         strategy:
             matrix:
                 php: [8.0, 8.1, 8.2, 8.3]
-                laravel: [12.*, 11.*, 10.*, 9.*, 8.*]
+                laravel: [12.*, 11.*, 10.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
                 include:
@@ -20,10 +20,6 @@ jobs:
                       testbench: 9.*
                     - laravel: 10.*
                       testbench: 8.*
-                    - laravel: 9.*
-                      testbench: 7.*
-                    - laravel: 8.*
-                      testbench: 6.*
                 exclude:
                     - laravel: 11.*
                       php: [8.1, 8.0]

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
             "Spatie\\Tags\\": "src"
         }
     },
-
     "autoload-dev": {
         "psr-4": {
             "Spatie\\Tags\\Test\\": "tests"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "laravel/framework": "^10.0|^11.0|^12.0",
         "nesbot/carbon": "^2.63|^3.0",
         "spatie/eloquent-sortable": "^3.10|^4.0",

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
     ],
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^8.67|^9.0|^10.0|^11.0",
+        "laravel/framework": "^8.67|^9.0|^10.0|^11.0|^12.0",
         "nesbot/carbon": "^2.63|^3.0",
         "spatie/eloquent-sortable": "^3.10|^4.0",
         "spatie/laravel-package-tools": "^1.4",
         "spatie/laravel-translatable": "^4.6|^5.0|^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.13|^7.0|^8.0|^9.0",
+        "orchestra/testbench": "^6.13|^7.0|^8.0|^9.0|^10.0",
         "pestphp/pest": "^1.22|^2.0",
         "phpunit/phpunit": "^9.5.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
     ],
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^8.67|^9.0|^10.0|^11.0|^12.0",
+        "laravel/framework": "^10.0|^11.0|^12.0",
         "nesbot/carbon": "^2.63|^3.0",
         "spatie/eloquent-sortable": "^3.10|^4.0",
         "spatie/laravel-package-tools": "^1.4",
         "spatie/laravel-translatable": "^4.6|^5.0|^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.13|^7.0|^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
         "pestphp/pest": "^1.22|^2.0",
         "phpunit/phpunit": "^9.5.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         "php": "^8.1",
         "laravel/framework": "^10.0|^11.0|^12.0",
         "nesbot/carbon": "^2.63|^3.0",
-        "spatie/eloquent-sortable": "^3.10|^4.0",
+        "spatie/eloquent-sortable": "^4.0",
         "spatie/laravel-package-tools": "^1.4",
-        "spatie/laravel-translatable": "^4.6|^5.0|^6.0"
+        "spatie/laravel-translatable": "^6.0"
     },
     "require-dev": {
         "orchestra/testbench": "^8.0|^9.0|^10.0",


### PR DESCRIPTION
This pull request adds support for Laravel 12 and removes support for Laravel 8 and 9, as they have been EOL for over a year. Additionally, PHP 8.4 testing has been added, while support for PHP 8.0 has been removed due to its EOL status for more than a year.