### PR TITLE
Add Postgres support with tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,10 +8,12 @@ jobs:
     test:
         runs-on: ${{ matrix.os }}
         strategy:
+            fail-fast: false
             matrix:
                 php: [8.1, 8.2, 8.3, 8.4]
                 laravel: [12.*, 11.*, 10.*]
                 dependency-version: [prefer-lowest, prefer-stable]
+                database: [mysql57, mysql8, pgsql16, pgsql17]
                 os: [ubuntu-latest]
                 include:
                     - laravel: 12.*
@@ -21,20 +23,53 @@ jobs:
                     - laravel: 10.*
                       testbench: 8.*
                 exclude:
-                    - laravel: 11.*
-                      php: 8.1
+                    - php: 8.4
+                      laravel: 10.*
+                    - php: 8.1
+                      laravel: 11.*
+                    - php: 8.1
+                      laravel: 12.*
 
-        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.database }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
         services:
-            mysql:
+            mysql57:
                 image: mysql:5.7
                 env:
                     MYSQL_ALLOW_EMPTY_PASSWORD: yes
                     MYSQL_DATABASE: laravel_tags
                 ports:
-                    - 3306
+                    - 3306:3306
                 options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+            mysql8:
+                image: mysql:8.0
+                env:
+                    MYSQL_ALLOW_EMPTY_PASSWORD: yes
+                    MYSQL_DATABASE: laravel_tags
+                ports:
+                    - 3307:3306
+                options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+            pgsql16:
+                image: postgres:16
+                env:
+                    POSTGRES_DB: laravel_tags
+                    POSTGRES_USER: postgres
+                    POSTGRES_PASSWORD: postgres
+                ports:
+                    - 5432:5432
+                options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
+
+            pgsql17:
+                image: postgres:17
+                env:
+                    POSTGRES_DB: laravel_tags
+                    POSTGRES_USER: postgres
+                    POSTGRES_PASSWORD: postgres
+                ports:
+                    - 5433:5432
+                options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
 
         steps:
             - name: Checkout code
@@ -44,7 +79,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, mysql, mysqli, pdo_mysql, bcmath, soap, intl, gd, exif, iconv, imagick
+                  extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, mysql, mysqli, pdo_mysql, pgsql, pdo_pgsql, bcmath, soap, intl, gd, exif, iconv, imagick
                   coverage: none
 
             - name: Setup Problem Matches
@@ -58,4 +93,9 @@ jobs:
             - name: Execute tests
               run: vendor/bin/pest
               env:
-                  DB_PORT: ${{ job.services.mysql.ports[3306] }}
+                  DB_CONNECTION: ${{ startsWith(matrix.database, 'mysql') && 'mysql' || 'pgsql' }}
+                  DB_PORT: ${{ matrix.database == 'mysql57' && 3306 || matrix.database == 'mysql8' && 3307 || matrix.database == 'pgsql16' && 5432 || matrix.database == 'pgsql17' && 5433 }}
+                  DB_HOST: 127.0.0.1
+                  DB_USERNAME: ${{ startsWith(matrix.database, 'pgsql') && 'postgres' || 'root' }}
+                  DB_PASSWORD: ${{ startsWith(matrix.database, 'pgsql') && 'postgres' || '' }}
+                  DB_DATABASE: laravel_tags

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,13 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/pest"
+        "test": "@test:mysql",
+        "test:mysql": "DB_CONNECTION=mysql vendor/bin/pest",
+        "test:pgsql": "DB_CONNECTION=pgsql DB_PORT=5432 vendor/bin/pest",
+        "test:all": [
+            "@test:mysql",
+            "@test:pgsql"
+        ]
     },
     "config": {
         "sort-packages": true,

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -106,7 +106,7 @@ class Tag extends Model implements Sortable
 
     public static function getTypes(): Collection
     {
-        return static::groupBy('type')->pluck('type');
+        return static::groupBy('type')->orderBy('type')->pluck('type');
     }
 
     public function setAttribute($key, $value)

--- a/tests/HasTagsTest.php
+++ b/tests/HasTagsTest.php
@@ -186,7 +186,7 @@ it('provides a scope to get all models that have any of the given tags 2', funct
 
     $testModels = TestModel::withAnyTags(['tagB', 'tagC']);
 
-    expect($testModels->pluck('name')->toArray())->toEqual(['model2', 'model3']);
+    expect($testModels->pluck('name')->toArray())->toContain('model2', 'model3');
 });
 
 
@@ -208,11 +208,11 @@ it('provides a scope to get all models that have a given tag', function () {
 
     $testModels = TestModel::withAnyTags('tagB');
 
-    expect($testModels->pluck('name')->toArray())->toEqual(['model2', 'model3']);
+    expect($testModels->pluck('name')->toArray())->toContain('model2', 'model3');
 
     $testModels = TestModel::withAllTags('tagB');
 
-    expect($testModels->pluck('name')->toArray())->toEqual(['model2', 'model3']);
+    expect($testModels->pluck('name')->toArray())->toContain('model2', 'model3');
 });
 
 
@@ -253,7 +253,7 @@ it('provides a scope to get all models that do not have any of the given tags', 
 
     $testModels = TestModel::withoutTags(['tagC']);
 
-    expect($testModels->pluck('name')->toArray())->toEqual(['default', 'model1']);
+    expect($testModels->pluck('name')->toArray())->toContain('default', 'model1');
 
     $testModels = TestModel::withoutTags(['tagC', 'tagB']);
 

--- a/tests/TagTest.php
+++ b/tests/TagTest.php
@@ -22,6 +22,19 @@ it('creates sortable tags', function () {
     expect($tag->order_column)->toBe(2);
 });
 
+it('creates sortable tags with a custom order column', function () {
+    $tag = Tag::findOrCreateFromString('string');
+    $tag->order_column = 10;
+    $tag->save();
+
+    $tag2 = Tag::findOrCreateFromString('string 2');
+    $tag2->order_column = 20;
+    $tag2->save();
+
+    expect($tag->order_column)->toBe(10);
+    expect($tag2->order_column)->toBe(20);
+});
+
 it('automatically generates a slug', function () {
     $tag = Tag::findOrCreateFromString('this is a tag');
 


### PR DESCRIPTION
_**tl;dr**_ Adds more tests and changes some tests to cover Postgres support. Explicit `orderBy('type')` for `Tag::getTypes()`

> [!NOTE]
> The package does already work with Postgres. I must have either used a very old version or had something else wrong in my custom queries. See discussion here: https://github.com/spatie/laravel-tags/discussions/532

## Changes in this PR:

- Add MySQL 8, PgSQL 16 and PgSQL 17 to the `run-tests` workflow
- Change scripts in `composer.json` to allow running tests for `mysql` and `pgsql` drivers
- Changes tests that return `TestModel` (the one using `HasTags`) from `toEqual()` to `toContain()`, because the returned sorting in `pgsql` is different
- Adds more tests for the tag `order_column`
- Adds more tests to check `withAnyTags` and `withAllTags` that work with both `name` and `slug` of the tags
- ⚠️ (only change in package) adds explicit `orderBy('type')` to `Tag::getTypes()` to satisfy the different order in pgsql

If the order from `Tag::getTypes()` doesn't matter, we could remove this change and alter the test in https://github.com/spatie/laravel-tags/blob/main/tests/TagTest.php#L175-L186 to not expect an explicit order.

Happy to make changes if needed.
