### PR TITLE
Add withAnyTagsOfType scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ $tag->swapOrder($anotherTag);
 // checking if a model has a tag
 $newsItem->hasTag('first tag');
 $newsItem->hasTag('first tag', 'some_type');
+
+// Retrieve models that have tags of a 
+Model::withAnyTagsOfType('type');
+Model::withAnyTagsOfType(['first type', 'second type']);
 ```
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).

--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -178,6 +178,14 @@ trait HasTags
         );
     }
 
+    public function scopeWithAnyTagsOfType(Builder $query, string|array $type): Builder
+    {
+        return $query->whereHas(
+            'tags',
+            fn (Builder $query) => $query->whereIn('type', (array) $type)
+        );
+    }
+
     public function tagsWithType(?string $type = null): Collection
     {
         return $this->tags->filter(fn (Tag $tag) => $tag->type === $type);

--- a/tests/HasTagsScopesTest.php
+++ b/tests/HasTagsScopesTest.php
@@ -26,6 +26,7 @@ beforeEach(function () {
 
     $typedTag = Tag::findOrCreate('tagE', 'typedTag');
     $anotherTypedTag = Tag::findOrCreate('tagF', 'typedTag');
+    $tagWithSecondType = Tag::findOrCreate('tagG', 'secondType');
 
     TestModel::create([
         'name' => 'model5',
@@ -36,8 +37,30 @@ beforeEach(function () {
         'name' => 'model6',
         'tags' => [$typedTag],
     ]);
+
+    TestModel::create([
+        'name' => 'model7',
+        'tags' => [$typedTag, $tagWithSecondType],
+    ]);
 });
 
+it('provides as scope to get all models that have any tags of the given types', function () {
+    // String input
+    $testModels = TestModel::withAnyTagsOfType('typedTag')->get();
+
+    expect($testModels->pluck('name')
+        ->toArray())
+        ->toContain('model5', 'model6')
+        ->not->toContain('model3', 'model7');    
+
+    // Array input
+    $testModels = TestModel::withAnyTagsOfType(['typedTag', 'secondType'])->get();
+
+    expect($testModels->pluck('name')
+        ->toArray())
+        ->toContain('model5', 'model6', 'model7')
+        ->not->toContain('model3');    
+});
 
 it('provides a scope to get all models that have any of the given tags', function () {
     $testModels = TestModel::withAnyTags(['tagC', 'tagD'])->get();


### PR DESCRIPTION
This update allows you to filter models that have any tags of a certain type.

For example, if you want to filter out users who are interested in planets as a type, but don't care whether it's specifically the Moon, Mars, Venus, or E.T., you can use this filter.

```
User::withAnyTagsOfType('comedy');

User::withAnyTagsOfType(['comedy', 'space']);
```