### PR TITLE
Update syncTagIds to public method

### DIFF
--- a/src/HasTags.php
+++ b/src/HasTags.php
@@ -283,7 +283,7 @@ trait HasTags
         })->flatten();
     }
 
-    protected function syncTagIds($ids, string | null $type = null, $detaching = true): void
+    public function syncTagIds($ids, string | null $type = null, $detaching = true): void
     {
         $isUpdated = false;
 


### PR DESCRIPTION
Use case: I use Laravel Tags for several different tag types, but some of the types are pre-created selections (i.e. existing "Categories") so I am able to sync directly with the tag ID instead of the name. 

The problem with syncing with only name is that some of my categories have the same tag name but distinct tag IDs. (Business requirement related to separate geographies on articles.)  

Risk: When tag IDs are already known, I see minimal risk to accessing the syncTagIds method directly when necessary. 

Thanks! 